### PR TITLE
fix(visualização): corrige legendas e rótulos dos gráficos de churn

### DIFF
--- a/TelecomX_BR.ipynb
+++ b/TelecomX_BR.ipynb
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 1,
    "id": "101e243e",
    "metadata": {},
    "outputs": [],
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 2,
    "id": "9f33e613",
    "metadata": {},
    "outputs": [
@@ -203,7 +203,7 @@
        "4  {'Contract': 'Month-to-month', 'PaperlessBilli...  "
       ]
      },
-     "execution_count": 46,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -278,7 +278,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 3,
    "id": "b1e4c177",
    "metadata": {},
    "outputs": [
@@ -525,7 +525,7 @@
        "4                      Yes          Mailed check                     83.9                 267.4  "
       ]
      },
-     "execution_count": 47,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -559,7 +559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 4,
    "id": "657130d2",
    "metadata": {},
    "outputs": [
@@ -862,7 +862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 5,
    "id": "af2c528d",
    "metadata": {},
    "outputs": [
@@ -1156,7 +1156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 6,
    "id": "cc8c2a30",
    "metadata": {},
    "outputs": [
@@ -1171,7 +1171,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\Acer\\AppData\\Local\\Temp\\ipykernel_12044\\295796550.py:21: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
+      "C:\\Users\\Acer\\AppData\\Local\\Temp\\ipykernel_28516\\295796550.py:21: FutureWarning: Downcasting behavior in `replace` is deprecated and will be removed in a future version. To retain the old behavior, explicitly call `result.infer_objects(copy=False)`. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
       "  df_t[bin_cols] = df_t[bin_cols].replace(bin_map)\n"
      ]
     },
@@ -1474,7 +1474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 7,
    "id": "2d367cfd",
    "metadata": {},
    "outputs": [
@@ -1516,7 +1516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 8,
    "id": "85420812",
    "metadata": {},
    "outputs": [
@@ -1830,7 +1830,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 9,
    "id": "0b42c580",
    "metadata": {},
    "outputs": [
@@ -1953,7 +1953,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 10,
    "id": "60b94ed3",
    "metadata": {},
    "outputs": [
@@ -2306,7 +2306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 11,
    "id": "b48ca2cb",
    "metadata": {},
    "outputs": [
@@ -2739,7 +2739,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 12,
    "id": "fe501a90",
    "metadata": {},
    "outputs": [
@@ -3092,7 +3092,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 13,
    "id": "df3b4c09",
    "metadata": {},
    "outputs": [
@@ -3466,7 +3466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 14,
    "id": "783047e9",
    "metadata": {},
    "outputs": [
@@ -3830,7 +3830,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 15,
    "id": "3b23f3e1",
    "metadata": {},
    "outputs": [
@@ -4195,7 +4195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 16,
    "id": "28dd81a2",
    "metadata": {},
    "outputs": [
@@ -4233,7 +4233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 17,
    "id": "9140edbc",
    "metadata": {},
    "outputs": [
@@ -4643,7 +4643,7 @@
        "account_Contract_two_year                       1.0  "
       ]
      },
-     "execution_count": 61,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4667,7 +4667,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 18,
    "id": "f1df6420",
    "metadata": {},
    "outputs": [
@@ -4867,7 +4867,7 @@
        "account_Contract_two_year                     0.318322     0.025682"
       ]
      },
-     "execution_count": 62,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4891,7 +4891,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 19,
    "id": "a8f7b4bd",
    "metadata": {},
    "outputs": [
@@ -5068,7 +5068,7 @@
        "phone_has_PhoneService                        0.296371"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5105,7 +5105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 20,
    "id": "3477a472",
    "metadata": {},
    "outputs": [
@@ -5149,7 +5149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 21,
    "id": "29c12039",
    "metadata": {},
    "outputs": [
@@ -5192,7 +5192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 22,
    "id": "f7744287",
    "metadata": {},
    "outputs": [
@@ -5200,18 +5200,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\Acer\\AppData\\Local\\Temp\\ipykernel_12044\\1614830843.py:3: FutureWarning: \n",
+      "C:\\Users\\Acer\\AppData\\Local\\Temp\\ipykernel_28516\\2574762751.py:3: FutureWarning: \n",
       "\n",
       "Passing `palette` without assigning `hue` is deprecated and will be removed in v0.14.0. Assign the `x` variable to `hue` and set `legend=False` for the same effect.\n",
       "\n",
-      "  ax = sns.countplot(data=df_t, x=\"Churn\", palette=\"pastel\")\n"
+      "  ax = sns.countplot(data=df_t, x=\"Churn\", palette=\"Set2\")\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAGGCAYAAACNCg6xAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjUsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvWftoOwAAAAlwSFlzAAAPYQAAD2EBqD+naQAARixJREFUeJzt3Qm8lOP///FP+74orVpEtC9CiYp2SkihRbuQ5JukvlGpUERSSBHRFymEilKyZGlT0qZUWrVv2vf5P97X73HPf86cc+qe4xznzDmv5+MxnZn7vueea6Z75v7c1/W5ritdIBAIGAAAAC4o/YU3AQAAgBA4AQAA+ETgBAAA4BOBEwAAgE8ETgAAAD4ROAEAAPhE4AQAAOATgRMAAIBPBE4AAAA+ETgBiWjQoEGWLl26f+W1brrpJnfzfPfdd+61P/7440R7jU2bNrl9vvPOOxE/V+XImzev3XDDDbZu3Tq7//777eWXX7Z/g8qs/4u0olWrVpYrVy7r3bu3HThwwH3uBw8eTPTXmTJliuXLl8+OHDnyj74fe/futZRk1qxZljNnTtuzZ09yFwVRgMAJiIeCBf3Ie7esWbNa0aJFrXHjxjZ69Gg7fPhworzO9u3b3Qll2bJllpoMHz7cBUtFihSxsmXL2tSpU+2OO+6waHTppZfGOBZCbzfffHOylm316tUuaB48eLBNmzbN8ufPbw0aNHDBU2I6e/asPfXUU9ajRw8XZISvmzBhggvkFVhlyZLFfWadOnWyX375xVI6/R+WLl3ahg0bltxFQRTImNwFAFK6IUOGWKlSpez06dO2c+dOd5Lq2bOnvfTSS+5EVbly5eC2/fv3t//+978RB0466elEU7VqVd/Pmz17tiW1kiVL2vHjxy1TpkwRP/ejjz6ySy65xDJmzOiu5FUjouAzWun/5rHHHou1XMF0crrssstsyZIl7rPWcaljVMFqYps+fbqtXbvWBcOhdHzceeedrtamTp069sQTT7jgSbWVqqF69913bcuWLVasWDFLyR544AFXY6fvoo5VID4ETsAF3HLLLXbNNdcEH/fr18+++eYbu/XWW+22226z33//3bJly+bWKUjQLSkdO3bMsmfPbpkzZ7ak5tW0JTTo8hQoUMCinQKTe++911Ia/f+obJI+ffokC+RUo6RmV++1PI8//rgLmkaOHOkCt1CqodLyf9vRo0ctR44cET2nRYsWrjZNAX/nzp2TrGyIfjTVAQlQr149GzBggG3evNnee++98+Y4zZkzx2rVquWaTtTEUaZMGXdVLqq9uvbaa919NWt4zT9eTpGaPipWrOhqFHQ1r4DJe254jlNos4m2KVy4sDt5KLjbunVrjG1Uu9WxY8dYzw3fZ3w5TmvWrLG7777bBUQKGvWennzyyeD6jRs3Wrdu3ezKK69069V8dNddd7n9hfvzzz/dOtVS6P1dd9119sUXX5gfJ0+etEcffdSVQ7UEeq/btm2Lc9u//vrLnRALFSrkmpIqVKhgb7/9tiWWF1980X1WOibCKdhWoKv8I/nhhx/cey5RooQrS/Hixd37UO1NKNUe6bhQbY22U03S7bffHuNz/PTTT61JkyYuYNI2l19+uT399NPuOAinoODqq692/ycXX3yxCwT1uVzIiRMnXHCkJsBQ+qzHjRtnDRs2jBU0SYYMGVwtTnhtk/KvdPzpO5EnTx73HnVB4Ce3Ljx/zfvOqcmyTZs2dtFFF7nvm3ec6wLnxx9/tOrVq7sgUzV0EydOjLXfggULutrjzz///IKfB9I2apyABGrXrp0LUNRk1rVr1zi3WbVqlfvh1g+ymvx0Ylu/fr399NNPbn25cuXc8oEDB7omkNq1a7vl119/fXAf+/btc7VeSgDWiU4n/vN59tln3Ymkb9++tnv3bpeQrROecqi8mrF/Yvny5a6car5TmXVy2rBhg2vK0WvLwoULbf78+da6dWt30lQgNXbsWBeU6QSnAEl27drl3qtOmo888ogLsNS0owBIyeXNmzc/b1nuu+8+F7jqhKn9qCawadOmsbbT6ygg0+fy8MMPu0Br5syZ1qVLFzt06FCcJ/1waqqNK6lZwak+VwWSffr0cc1TqoUJpWWNGjVyJ3UvgNF7VnCp97xo0SJ75ZVXXCCidaG1IDqGVBOiz1n/nwrE1fSlx6LgT0Fjr169XFm+/fZbdzzpfb3wwgvBfSkIUYCiQF25PPpMRo0a5Y7FX3/99bw5UQrcT506ZdWqVYuxXJ/hmTNn3HchEvqs1PytcixdutTGjx/vApfnn3/eEkqB6BVXXGFDhw61QCAQXK7vW8uWLd3/dYcOHdznpaBNAaSC51Ba9tlnnyW4DEgjAgDiNGHCBP36BhYvXhzvNnny5AlcddVVwcdPPfWUe45n5MiR7vGePXvi3Yf2r230euFuvPFGt27s2LFxrtPN8+2337ptL7nkksChQ4eCy6dMmeKWjxo1KrisZMmSgQ4dOlxwnxs3boxVtjp16gRy5coV2Lx5c4znnjt3Lnj/2LFjsfY9f/58t6+JEycGl/Xs2dMt++GHH4LLDh8+HChVqlTg0ksvDZw9ezYQn2XLlrnnPvTQQzGWt2nTxi3X/4WnS5cugSJFigT27t0bY9tWrVq5/8O4yhtKn5f2Gddt2LBhwe1q1qwZuPrqq2M8d9GiRbHed1yvp/2kS5cu+LkeOHDAPe+FF144b9mOHj0aa9kDDzwQyJ49e+DEiRPu8alTpwIFCxYMVKxYMXD8+PHgdjNmzHCvMXDgwPO+xvjx4912K1asiLH80Ucfdct//fXXgB/e96Nz584xljdv3jyQP3/+8x53nvD/W2+frVu3jvf/bd68ecFlu3fvDmTJkiXw2GOPxdp+6NChbvtdu3b5ej9Im2iqA/4BNb2dr3eddxWv6v9z584l6DVUS6WaAr/at28fI7lVV9tq4vnyyy/tn1KS97x581yTl5qZQoU2UYbWbKmmRrVm6rWkz0M1DB6VSU0oXtOK95mqJkvNNaqdio/3flRTFSq89kjn2k8++cSaNWvm7qvWyLuph+Tff/8do0zxqVGjhqvtCb+pVs1zzz33uNoZ1cB5Jk+e7P4P1cQW1+ejfByVRTVmKp9qf7xt1Lyn5lyviS8uXu2d6FjUvlQjqBotNamKeraptuqhhx6KkbOm2jn1eLxQ06j+/8SrMfOoVksiTaZ+8MEHYzxWefUa3v4SInyfnvLlywdrckW1jWpaVhNxOO/9pbThEpCyEDgB/4DGsznfSUMnUiXUqklJTWxqblOzTSRBlJJxI0kEV3NFeECjoCWu/KJIeScb5V2dj3J11Fyk3B0FDcqn0QlLuS0KVDzKB9JJLJyaML318dE6JUMrpydU+P4U7Ol133jjDVeG0JsXkCqouBC9BzV5ht9Ck+DVXKQyKVgSBUJqelNTa+7cuYPbqalNzUXK61KgqLLceOONbp33+ehzU9OVmsN07CjHTUM8KO8plJry1KSpXCG9hvblJbF7+/I+x7g+awVO5/ucQ4U2gYn3niIdmiM86PYClvMFiBeipj8/r+W9Xlyv5b2/f2ssNkQncpyABFI+ik5MCkrio1oD1dAo70RX9Uqw1UlVyeXKjVLy7IUkRl5SuPhODEoo9lOmC1FOjnphqfanZs2a7qSu11TgmNCat4TyXk/BhHJc4hI6pMQ/oQRt1W4oOFb+24IFC1yQFJq7o89YydT79+93eWgKXJSbpCRtBVOhn48+P9WUKe/mq6++ch0SlBekXK6rrrrKBYQKuBTAKFdOQaRqlFSDpn0n1metPCxRsBGa6K2yy4oVKyIaSiO+Y+xCgUtcCe8X+p5c6LVCecGUgmQgPgROQAL973//c3/V3HM+qoGoX7++u2nsJyWvqgeaginVWCT21a1G6Q4/QShBNjQ40BV3XCNLq+ZBvY7i461buXLlecugxG4FKSNGjIjRMyv8NVVbo7GBwnlNTKG1OeG0ToGBmsVCa1LC9+f1uNNJN7xXWFJQLaOaxFQOBclqSlPw41GQ8ccff7gkeDWretTsFxcFQxo/Sjf93ypA0eeqpHg146mJS4OLqkbKo2T8UN7nqDIpaA+lZef7nEMDJO23UqVKweWqSVNgorJEmiB+Pl4NVPjx4rdmLKH0/rzaUSA+NNUBCaArfnX5VvNA27Zt491OtQrhvCtzdaUXb7yZxJoiQ12tQ5tOFMTs2LHDneRCT8aqDVFPKc+MGTNiDVsQTicUnaDVM0k1KfFdwetkGn5Fr15j4TUG6kavHmXqgRea86NmNfUaU35KfLz3o1HcQ4VP66KyqHea8pziCvgSe5oNvZZec9KkSa6ZTr0qQ8cU8mpAQj8f3VcPt1DKUVKwGUr/bwoCvWMnrn3p/3TMmDExnqdxyNRrTT0bveeKmgE1DllcPRHDe5upuTh8FHA1xapHqWpP9f8bToGtgrz4hoiIj2rQFMCotjZU+PtKbMpPUw0pcD7UOAEXoJOLakDU7VpduBU0qXZAV+kaOfx8A0Sq+UQ//joxaXvl0ujHX80dXkK0ToZKmtZJTSdFnWSViBxfzsaFKG9G+1b+jsqrQELNiaFDJijnSgGVpppQ13DV2qjWIDxfKC4KVLR/dU1XErfKqfwpNUV608YoWFCNnJroFPwoMPr666+DTT4ejbKuAENBkJK8VXbVxOjKX4GOauviowBUidn6PNVkquTquXPnutq1cM8995yr4dPnqs9BZVJQqyYtlSuuADecmtJCx+zyKEcpdCoZBSh169Z1tYsKYFUDFV57o89Z4xtpnwoS9F7Dc25UK6VaSv3/qLwaWFVjNun/VE2eoves2hnV7unzU+2lPvfwoFVDR6i5UMeEmvb0uXnDEShA1RhS56NjXMMp6LPSMR1KgZGOH72+ar70f68yKbBW4KjvjlfeSOgY1f+b/irw0/dIn0lS0XdTQ2107949yV4DqURyd+sDUvpwBN4tc+bMgcKFCwcaNmzouvaHdvmPbziCuXPnBm6//fZA0aJF3fP1V92m//jjjxjP+/zzzwPly5cPZMyYMUY3bA0NUKFChTjLF99wBJMmTQr069fPdT/Pli1boGnTprGGDpARI0a4oQvUNfuGG24I/PLLL76GI5CVK1e6LuS5c+d268uUKRMYMGBAcL260nfq1Clw8cUXB3LmzBlo3LhxYM2aNXEOg7Bhw4ZAy5YtA3nz5g1kzZo1UL16dddN3g91rX/kkUdcV/YcOXIEmjVrFti6dWusLuuiLubdu3cPFC9ePJApUyb3f1m/fv3AG2+8ccHXOd9wBFoX7s0333TrNGxDaPd/z+rVqwMNGjRwn40+o65duwZ+++23GJ+1hk5QecuWLevem4ZNqFGjhhteItRPP/0UuO6669z/tY6vPn36BL766iu3Lx0ToSZPnuyGz9D/eb58+QJt27YNbNu2zddnPXXqVDdcwpYtW2KtO3PmjBuyoHbt2q6c+nz1uegYCB2qwPt+hA/P4X3XdLyFDtmgYSS0P32Od999txtKIL7hCOIa8kNl0PEfLvw4l9dff90N4RDX9xoIlU7/JHfwBiB6KW9IAz+qRgKpl5pZVfOlGjA1U6c2SrbXAK3JMUUMogs5TgD+ESU+x9WEhdRF+VRqpnvttdfcMBypiXq7KvFeU+MAF0KNE4AEUW6SErk1lYfyepTfAgCpHTVOABJEAy9q3jclOCvRGQDSAmqcAAAAfKLGCQAAwCcCJwAAAJ8YANMHjX67fft2Nzghkz8CAJC6KGtJA9ZqvsnzDbwrBE4+KGjS1AIAACD10rRToRNZx4XAyQfVNHkfqKZHAAAAqcehQ4dcBYl3vj8fAicfvOY5BU0ETinToEGDbPDgwTGWlSlTxs2TJZo09oMPPnBzk6k6VvOCaX44j2aZ1/xicdEktNdee22MZZoPTSMNa1DAC03Oqzm7unXr5uZK07xmmlds2LBhbu4xAEDK4Scdh19upBoVKlRwk5B6QgMTzTSvCW11i2t0YE2WumPHjhjLBgwY4CaN1QSjoU6fPu0mSa1du7b9/PPPF5ymQhP8Fi5c2G2r12jfvr2bdHXo0KH/4N0CAJIDgRNSDQVKClDi0rNnz2DNUlwyZ84c47kKjj7//HPr0aNHrCuQ/v37uxnuNXP9hQKn2bNn2+rVq11AV6hQIatataqb56tv376ulkyvCwCIHgxHgFRDc02pR8Rll11mbdu2dU1kCTVt2jTbt2+fderUKcbyb775xj766CM3X5cf8+fPt0qVKrmgydO4cWPXnq6RtwEA0YXACalCjRo13Jxpmqzz9ddft40bN7qmNOUzJcRbb73lApzQ3hUKpDp27Ohex2+u286dO2METeI91joAQHShqQ6pwi233BK8X7lyZRdIlSxZ0qZMmWJdunSJaF/btm2zr776yj03VNeuXa1NmzZWp06dRCs3ACC6UOOEVEk95q688krX+y1SEyZMsPz589ttt90Wq5nuxRdfdLlUuikg+/vvv939t99+O859KW9q165dMZZ5j+PLxwIApFwETkiVjhw5Yhs2bLAiRYpEPHqsAiev51t4vtKyZcuCtyFDhrgxP3S/efPmce6vZs2atmLFCtu9e3dw2Zw5c1xTX/ny5RP47gAAyYXACalC79697fvvv7dNmza5nm4KZDTGkoYN8PKJFOB4NVAKZvR4//79sWqVlB913333xXqNcuXKWcWKFYO3Sy65xA3Nr/sXXXSR2+bTTz91Pe48jRo1cgFSu3bt7LfffnNNgOqV1717d8uSJUsSfyoAgMRG4IRUQXlJCpI06OXdd9/tmtoWLFhgBQoUcOvHjh3rBqxUnpIoT0mP1XsuPClcYzqFBj+RUNPd2rVrg48VvM2YMcP9Ve3Tvffe62qzVFsFAIg+6QJqm8B5qet4njx53EmRkcMBAEi753lqnAAAAHwicAIAAPCJcZxSmI8X7UnuIgApXsvq/5e7BgD/NmqcAAAAfCJwAgAA8InACQAAwCcCJwAAgGgInAYNGmTp0qWLcQsdePDEiRNuhGUNZpgzZ05r0aJFrHm/tmzZYk2bNrXs2bNbwYIF7fHHH7czZ87E2Oa7776zatWquZGaS5cu7Wa3BwAAiLoapwoVKtiOHTuCtx9//DG47tFHH7Xp06fbRx995KbT2L59u915553B9WfPnnVB06lTp9w0G++++64LigYOHBjcRtNnaJu6deu6KTZ69uzpptPQ1BcAAABRNRyBZpaPa5Z4jd6p6S8++OADq1evnlumyVc1X5im0rjuuuts9uzZtnr1avv666+tUKFCVrVqVXv66aetb9++rjYrc+bMbqqNUqVK2YgRI9w+9HwFZyNHjrTGjRv/6+8XAABEr2SvcVq3bp0VLVrULrvsMmvbtq1repMlS5bY6dOnrUGDBsFt1YxXokQJN0u96G+lSpVc0ORRMKSh01etWhXcJnQf3jbePgAAAKKixqlGjRquaU0Ts6qZbvDgwVa7dm1buXKlm81eNUZ58+aN8RwFSVon+hsaNHnrvXXn20bB1fHjxy1btmyxynXy5El382hbAACAZA2cbrnlluD9ypUru0CqZMmSNmXKlDgDmn/LsGHDXBAHAACQoprqQql26corr7T169e7vCclfR88eDDGNupV5+VE6W94Lzvv8YW20ezH8QVn/fr1czlW3m3r1q2J+j4BAEB0SlGB05EjR2zDhg1WpEgRu/rqqy1Tpkw2d+7c4Pq1a9e6HKiaNWu6x/q7YsUK2717d3CbOXPmuKCofPnywW1C9+Ft4+0jLhq2QPsIvQEAACRr4NS7d283zMCmTZvccALNmze3DBkyWOvWrS1PnjzWpUsX69Wrl3377bcuWbxTp04u4FGPOmnUqJELkNq1a2e//fabG2Kgf//+buwnBT/y4IMP2p9//ml9+vSxNWvW2JgxY1xToIY6AAAAiJocp23btrkgad++fVagQAGrVauWG2pA90VDBqRPn94NfKlkbfWGU+DjUZA1Y8YM69atmwuocuTIYR06dLAhQ4YEt9FQBF988YULlEaNGmXFihWz8ePHMxQBAACIWLpAIBCI/Glpi3rVqQZM+U5J3Wz38aI9Sbp/IDVoWf3/Lq4A4N8+z6eoHCcAAICUjMAJAADAJwInAAAAnwicAAAAfCJwAgAA8InACQAAwCcCJwAAAJ8InAAAAHwicAIAAPCJwAkAAMAnAicAAACfCJwAAAB8InACAADwicAJAADAJwInAAAAnwicAAAAfCJwAgAA8InACQAAwCcCJwAAAJ8InAAAAHwicAIAAPCJwAkAAMAnAicAAACfCJwAAAB8InACAADwicAJAADAJwInAAAAnwicAAAAfCJwAgAA8InACQAAwCcCJwAAAJ8InAAAAHwicAIAAPCJwAkAAMAnAicAAACfCJwAAAB8InACAADwicAJAADAJwInAAAAnwicAAAAfCJwAgAASKrAaevWrbZt27bg40WLFlnPnj3tjTfeiHRXAAAAqTtwatOmjX377bfu/s6dO61hw4YueHryySdtyJAhSVFGAACA6AycVq5cadWrV3f3p0yZYhUrVrSff/7Z3n//fXvnnXeSoowAAADRGTidPn3asmTJ4u5//fXXdtttt7n7ZcuWtR07diR+CQEAAKI1cKpQoYKNHTvWfvjhB5szZ47dfPPNbvn27dstf/78CS7Ic889Z+nSpXP5Up4TJ05Y9+7d3X5z5sxpLVq0sF27dsV43pYtW6xp06aWPXt2K1iwoD3++ON25syZGNt89913Vq1aNRfwlS5dmpoxAADw7wROzz//vI0bN85uuukma926tVWpUsUtnzZtWrAJL1KLFy92+6xcuXKM5Y8++qhNnz7dPvroI/v+++9dcHbnnXcG1589e9YFTadOnXLNhe+++64LigYOHBjcZuPGjW6bunXr2rJly1xgdt9999lXX32VoLICAIC0K10gEAhE+iQFLIcOHbKLLroouGzTpk3BWp9IHDlyxNUGjRkzxp555hmrWrWqvfzyy/b3339bgQIF7IMPPrCWLVu6bdesWWPlypWz+fPn23XXXWczZ860W2+91QVUhQoVctuoNqxv3762Z88ey5w5s7v/xRdfuNwsT6tWrezgwYM2a9YsX2XUe82TJ48rU+7cuS0pfbxoT5LuH0gNWlYvkNxFAJCKRHKeT9A4Toq1lixZ4mqJDh8+7JYpSFHgFCk1xalGqEGDBjGWa//KpwpdrjyqEiVKuMBJ9LdSpUrBoEkaN27sPoBVq1YFtwnft7bx9gEAAOBXRovQ5s2bXV6TcotOnjzphiPIlSuXa8LTY9X4+PXhhx/a0qVLXVNdOA11oGAsb968MZYrSNI6b5vQoMlb76073zYKro4fP27ZsmWL9dp6H7p5tC0AAEDENU7/+c9/7JprrrEDBw7ECDqaN29uc+fOjWggTe1LwxhkzZrVUpJhw4a5KjvvVrx48eQuEgAAiMbASb3p+vfv72qDQl166aX2119/+d6PmuJ2797t8psyZszobkoAHz16tLuvWiElfSsXKZR61RUuXNjd19/wXnbe4wttozbMuGqbpF+/fq6d07spyAMAAIg4cDp37pxLDg+naVjUZOdX/fr1bcWKFa6nm3dTTVbbtm2D9zNlyhSjFmvt2rWuibBmzZrusf5qHwrAPBoiQUFR+fLlg9uE14RpG28fcdGwBdpH6A0AACDiHKdGjRq5Xm/e3HQae0k945566ilr0qSJ7/0oyNKo46Fy5Mjhxmzylnfp0sV69epl+fLlc8FLjx49XMCjHnVeWRQgtWvXzoYPH+7ymVQbpoRzb5DOBx980F599VXr06ePde7c2b755hs34rl62gEAACRp4DRixAjXK00Biwao1Nx169ats4svvtgmTZpkiWnkyJGWPn16N/ClkrX1uhq2wJMhQwabMWOGdevWzQVUCrw6dOgQY868UqVKuSBJY0KNGjXKihUrZuPHj3f7AgAASPJxnDQy9+TJk+23334LjsOkJrb4coaiHeM4ASkL4zgBSK7zfMQ1TvPmzbPrr7/eBUq6hQZTWlenTp2ElRoAACC1JYdr6pL9+/fHWq4oTesAAABSq4gDJ7XsKSE83L59+1yOEQAAQGrlu6nOm1xXQVPHjh2DvdZEwxMsX77cNeEBAABYWg+clDTl1ThpKIHQRHANhqkhArp27Zo0pQQAAIimwGnChAnBEcJ79+5NsxwAAEhzIu5Vp4EuAQAA0qKIk8M1z5tG6i5atKibU06DUIbeAAAAUquIa5yUGK754gYMGGBFihSJs4cdAABAahRx4PTjjz/aDz/8YFWrVk2aEgEAAKSWprrixYu7nnUAAABpTcSB08svv2z//e9/bdOmTUlTIgAAgNTSVHfPPffYsWPH7PLLL7fs2bNbpkyZYqyPazoWAACANBk4qcYJAAAgLYo4cOrQoUPSlAQAACC15TjJhg0brH///ta6dWvbvXu3WzZz5kxbtWpVYpcPAAAgegOn77//3ipVqmQLFy60qVOn2pEjR9zy3377jVHFAQBAqhZx4KQedc8884zNmTPHTe7rqVevni1YsCCxywcAABC9gdOKFSusefPmsZYXLFjQ9u7dm1jlAgAAiP7AKW/evLZjx45Yy3/99Ve75JJLEqtcAAAA0R84tWrVyvr27Ws7d+5089SdO3fOfvrpJ+vdu7e1b98+aUoJAAAQjYHT0KFDrWzZsm7qFSWGly9f3urUqWPXX3+962kHAACQWkU8jpMSwt98800bMGCArVy50gVPV111lV1xxRVJU0IAAIBoDZw8JUqUcDcAAIC0wlfg1KtXL3v66actR44c7v75vPTSS4lVNgAAgOgLnNRj7vTp08H78VGyOAAAQJoOnL799ts47wMAAKQlCZqrDgAAIC3yVeN05513+t6h5q8DAABIs4FTnjx5kr4kAAAAqSFwmjBhQtKXBAAAILXkOJ04ccKmTZtmhw8fjrXu0KFDbt3JkycTu3wAAADRFziNGzfORo0aZbly5Yq1Lnfu3DZ69Gg3ojgAAICl9cDp/ffft549e8a7XusmTpyYWOUCAACI3sBp3bp1VqVKlXjXV65c2W0DAABgaT1wOnPmjO3Zsyfe9VqnbQAAACytB04VKlSwr7/+Ot71s2fPdtsAAABYWg+cOnfu7Cb6nTFjRqx106dPt2effdZtAwAAkKbHcZL777/f5s2bZ7fddpuVLVvWypQp45avWbPG/vjjD7v77rvdNgAAAKlVRHPVvffee/bhhx/alVde6YKltWvXugBq0qRJ7gYAAJCa+a5x8qhmSTcAAIC0JqIaJwAAgLSMwAkAAMAnAicAAACfCJwAAACSOnBav369ffXVV3b8+HH3OBAIRLyP119/3U3VokmCdatZs6bNnDkzuP7EiRPWvXt3y58/v+XMmdNatGhhu3btirGPLVu2WNOmTS179uxWsGBBe/zxx2ONYP7dd99ZtWrVLEuWLFa6dGl75513Evq2AQBAGhZx4LRv3z5r0KCBG5KgSZMmtmPHDre8S5cu9thjj0W0r2LFitlzzz1nS5YssV9++cXq1atnt99+u61atcqtf/TRR93gmh999JF9//33tn37drvzzjuDzz979qwLmk6dOmU///yzvfvuuy4oGjhwYHCbjRs3um3q1q1ry5Ytc5MR33fffS7oAwAAiES6QIRVRe3bt7fdu3fb+PHjrVy5cvbbb7/ZZZdd5gKRXr16BYOehMqXL5+98MIL1rJlSytQoIB98MEH7r432KZec/78+Xbddde52qlbb73VBVSFChVy24wdO9b69u3r5s7LnDmzu//FF1/YypUrg6/RqlUrO3jwoM2aNctXmQ4dOmR58uSxv//+29WMJaWPF8U/HyCA/9OyeoHkLgKAVCSS83zENU6ak+755593tUWhrrjiCtu8ebMllGqPNLjm0aNHXZOdaqFOnz7tarc8GrG8RIkSLnAS/a1UqVIwaJLGjRu7D8AL4LRN6D68bbx9AAAAJNkAmApslE8Ubv/+/S6HKFIrVqxwgZLymZTH9Omnn1r58uVds5pqjPLmzRtjewVJO3fudPf1NzRo8tZ76863jYIr5Wdly5YtVplOnjzpbh5tCwAAEHGNU+3atW3ixInBx+nSpbNz587Z8OHDXR5RpDRli4KkhQsXWrdu3axDhw62evVqS07Dhg1zVXberXjx4slaHgAAEKU1TgqQ6tev75K5lZTdp08f1yymGqeffvop4gKoVkk93eTqq6+2xYsX26hRo+yee+5x+1cuUmitk3rVFS5c2N3X30WLFsXYn9frLnSb8J54eqw2zLhqm6Rfv34uXyu0xongCQAARFzjVLFiRTfBb61atVwPODXdqafbr7/+apdffvk/LpBqr9RMpiAqU6ZMNnfu3OA6TSqs4QfUtCf6q6Y+Jat75syZ44IiNfd524Tuw9vG20dc1OToDZHg3QAAACKucRI1Xz355JP/+MVVs3PLLbe4hO/Dhw+7HnQac0k99PQaGuJANT/qaafgpUePHi7gUY86adSokQuQ2rVr52rClM/Uv39/N/aTl2/14IMP2quvvupqxjp37mzffPONTZkyxfW0AwAASPTAafny5b53qAEt/VJNkYY30FhQCpT0XAVNDRs2dOtHjhxp6dOndwNfqhZKveHGjBkTfH6GDBlsxowZLjdKAVWOHDlcjtSQIUOC25QqVcoFSRoTSk2A6g2ooRS0LwAAgEQfx0nBi5LAtan+erynhi7TsAKpDeM4ASkL4zgBSNHjOGn07T///NP9/eSTT1wtjmp+1BtON91XfpPWAQAApOmmupIlSwbv33XXXTZ69Gg33YpHTWzqdTZgwAC74447kqakAAAA0darTr3YVOMUTsuSe/wlAACAFBU4aa44DRCpMZY8uq9lWgcAAJBaRTwcgSbRbdasmeud5vWgU687JYhPnz49KcoIAAAQnYFT9erVXaL4+++/b2vWrHHLNMp3mzZt3HAAAAAAqVWCBsBUgHT//fcnfmkAAABSU44TAABAWkXgBAAA4BOBEwAAgE8ETgAAAEkZOB08eNBNlNuvXz/bv3+/W7Z06VL766+/ErI7AACA1NmrTmM2NWjQwE2Gt2nTJuvatavly5fPpk6dalu2bLGJEycmTUkBAACircapV69e1rFjR1u3bp1lzZo1uFxz182bNy+xywcAABC9gdPixYvtgQceiLX8kksusZ07dyZWuQAAAKI/cMqSJYsdOnQo1vI//vjDChQokFjlAgAAiP7A6bbbbrMhQ4bY6dOn3WPNUafcpr59+1qLFi2SoowAAADRGTiNGDHCjhw5YgULFrTjx4/bjTfeaKVLl7ZcuXLZs88+mzSlBAAAiMZedepNN2fOHPvxxx9dDzsFUdWqVXM97QAAAFKzBE3yK7Vq1XI3AACAtMJX4DR69GjfO3zkkUf+SXkAAACiO3AaOXJkjMd79uyxY8eOWd68eYMjiWfPnt3lPRE4AQCANJ0cvnHjxuBNCeBVq1a133//3U23opvuK8/p6aefTvoSAwAAREuvugEDBtgrr7xiZcqUCS7TfdVK9e/fP7HLBwAAEL2B044dO+zMmTOxlp89e9Z27dqVWOUCAACI/sCpfv36bsqVpUuXBpctWbLEunXrxpAEAAAgVYs4cHr77betcOHCds0117jpV3SrXr26FSpUyMaPH580pQQAAIjGcZw0H92XX37p5qZbs2aNW1a2bFm78sork6J8AAAA0T8ApgIlgiUAAJCWJChw2rZtm02bNs1N7nvq1KkY61566aXEKhsAAEB0B05z58612267zS677DLXVFexYkXbtGmTBQIBN5YTAABAahVxcni/fv2sd+/etmLFCsuaNat98skntnXrVrvxxhvtrrvuSppSAgAARGPgpFHC27dv7+5nzJjRjh8/bjlz5rQhQ4bY888/nxRlBAAAiM7AKUeOHMG8piJFitiGDRuC6/bu3Zu4pQMAAIjmHKfrrrvOfvzxRytXrpw1adLEHnvsMddsN3XqVLcOAAAgtYo4cFKvuSNHjrj7gwcPdvcnT55sV1xxBT3qAABAqhZx4KTedKHNdmPHjk3sMgEAAKSOHCcAAIC0yleN00UXXWTp0qXztcP9+/f/0zIBAABEb+D08ssvB+/v27fPnnnmGWvcuLHVrFnTLZs/f7599dVXNmDAgKQrKQAAQDJLF9CQ3xFo0aKF1a1b1x5++OEYy1999VX7+uuv7bPPPrPU5tChQ5YnTx77+++/LXfu3En6Wh8v2pOk+wdSg5bVCyR3EQCk0fN8xDlOqlm6+eabYy3XMgVOAAAAqVXEgVP+/Pnt888/j7Vcy7QOAAAgtYp4OAKN3XTffffZd999ZzVq1HDLFi5caLNmzbI333wzKcoIAAAQnTVOHTt2tJ9++sm1AWq0cN10X6OJax0AAElt3rx51qxZMytatKjr9R2eX6vBmZWLW6xYMcuWLZuVL18+znEH1bmpXr16blxCncvq1Knj5mD1LF261Bo2bGh58+Z1rSr3339/cBDo+Ch1eODAgW5aMr12gwYNbN26dYn47hF14zippun99993B5Ruuu/VPkVi2LBhdu2111quXLmsYMGCdscdd9jatWtjbHPixAnr3r27O2A1mbCS03ft2hVjmy1btljTpk0te/bsbj+PP/64nTlzJsY2qiGrVq2aZcmSxUqXLm3vvPNOQt46ACAFOHr0qFWpUsVee+21ONf36tXLtYS89957bnL6nj17ukBq2rRpMYIm5ec2atTIFi1aZIsXL3bbpE//f6fG7du3u6BH5wyvZWXVqlUXrCQYPny4jR492gVqep6CMvVE1/kMaaRXnbLNvSxz3T+fSHqd6YBt1aqVC54U6DzxxBO2cuVKW716tTvQpFu3bvbFF1+4QEcZ795BrVovOXv2rFWtWtUKFy5sL7zwgu3YscPat29vXbt2taFDh7ptNm7caBUrVrQHH3zQNTPOnTvXfYm0Xx3Mft4/veqAlINedQilGqdPP/3UXXx79Jt/zz33xBgm5+qrr7ZbbrnFDakjml9VtUlPP/10nPt944033PN1XvGCKc3NWrlyZVeDpIAqnE6pqgXTPK69e/d2y3TuKFSokDuP6ZyHlCfRe9VpAMzdu3e7+6qu1OPwm7c8EoreFblXqFDBXTnooFLt0ZIlS9x6vYG33nrLzYGnqlQd9BMmTLCff/7ZFixY4LaZPXu2C7R0VaEASl8KfQl0FXLq1Cm3jaL+UqVK2YgRI9zkxAq+WrZsaSNHjoyovACA6HD99de72qW//vrLBTPffvut/fHHH652SXROU22QWim0rQKbG2+80aWdeE6ePGmZM2cOBk2ipjcJ3S6ULtR37tzpaqo8OiGrVUY1XIh+vgKnb775xvLly+fu6+DT4/Cbt/yfUKAk3mspgDp9+nSMA7Bs2bJWokSJ4AGov5UqVXIHvUe1SIoeVaXqbRO6D28bDmIASJ1eeeUVl9ekHCcFP2rh0AW1cpjkzz//dH8HDRrkWih0Ia90jvr16wfzkXTBriBIrRm6ED9w4ID997//detUCxUXbS+h5yTvsbcOaaBXnaJwj2puihcvHmsKFkX0W7duTXBBzp0755rPbrjhBlfFKjrIdMCrNiu+A1B/4zpAvXXn20bBlZIAvSuI0KsM3TwXap4EAKS8wEktE6p1KlmypEsmV76smtF0Ia1zjjzwwAPWqVMnd/+qq65yqRxvv/22y8FVa8i7777r8qX69etnGTJksEceecSdP0JroZC2RPw/r8Bpz549cc5Rp3UJpQNa+U0ffvihJTd9YVS16t0UKAIAooMuiJUzqzQP9bxTTpJSNJTz9OKLL7pt1ONNVCsVSukcShnxtGnTxl18q8lPU46phkrnwMsuuyzO11a+rYR3YtJjbx3SWOCkmqW4JvxV98ysWbMmqBA6oGfMmOGa+1St6tFBpurRgwcPxnsA6m9cB6i37nzbKAEsvLZJdGWhZkPv9k9q0gAA/y6leOgWXiukGiOvpunSSy91tU/hPbmVB6UaqnCqZVLP7smTJ7tznZLK46IKBJ1zVHMV2mqhfCpvflekkQEwVVUpCprUy0Bd/z3q2aaDQsnZkQZhPXr0cL0hNFxAeI2VksEzZcrkDkANQyA6yHU14B2A+vvss8+6RD8l+cmcOXNcUORdSWibL7/8Msa+tU18B7GGLNANAJAy6WJ9/fr1MZKyly1b5nJklQerFBMNTaOLYwVC33//vU2cONHVQnnnMq1/6qmnXOcknb/ULLdmzRr7+OOPY8zDquRxBU06b+g5zz33XIwUEuXeqqWiefPmbr9KO1HPvSuuuMKd13TOVJAW2usPaSBw+vXXX4PBjrpjKvfIo/s68Lyul5E0z33wwQduuhaN5eTlJKl5TAe7/nbp0sUFbfoyKBhSoKWAR91IRT0kFCC1a9fOjZ2hffTv39/t2wt+NAyBDv4+ffpY586dXRL7lClT3HAEAIDo88svv7gJ58Mv7jt06OB6aCvtQ60Hbdu2dakkCp50ka3zgUcBjsZWevTRR902Oo8pOLr88suD22h8JwVXCtQUII0bN86db0Lpgt7r3CQ612icKQ2WqRaTWrVqueTzhLbKIArHcQqlJLpRo0YlynhGcTX5iYYc8AYY00Gt8TAmTZrkErbVG27MmDEx2oo3b97sxntSrZXGf9IXR1cEGTP+/7hQ6/Tl0NAFag7UFYDfkc4ZxwlIWRjHCUBiiuQ8H3HglBYROAEpC4ETgOQ6z0c8ya+qH1Wbo7wj5RV5iXYeb2wMAACA1CbiwElTlijJTm286s4ZX3MbAOD8Ds56JbmLAESFvDf3sKgNnGbOnOmSqjVQJQAAQFoS8ThOmo/OmxIFAAAgLYk4cNIEugMHDrRjx44lTYkAAABSqIib6kaMGGEbNmxwo6hq5FUNUBlq6dKliVk+AACA6A2cGPkUAACkVREHThpBFQAAIC2KOMcJAAAgrYq4xkkT+o4cOdLN9abJdk+dOhVjveb7AQAASI0irnEaPHiwm136nnvucUOTa2LFO++809KnT2+DBg1KmlICAABEY+D0/vvv25tvvukm3tUkuq1bt7bx48e7IQoWLFiQNKUEAACIxsBp586dVqlSJXc/Z86crtZJbr31VjeiOAAAQGoVceBUrFgx27Fjh7t/+eWX2+zZs939xYsXW5YsWRK/hAAAANEaODVv3tzmzp3r7vfo0cMGDBhgV1xxhbVv3946d+6cFGUEAACIzl51zz33XPC+EsRLlChh8+fPd8FTs2bNErt8AAAA0Rs4hatZs6a7AQAApHYRB04TJ04873o12QEAAKRGEQdO//nPf2I8Pn36tB07dswyZ85s2bNnJ3ACAACpVsTJ4QcOHIhxO3LkiK1du9Zq1aplkyZNSppSAgAApJa56pQYrqTx8NooAACA1CTRJvnVKOLbt29PrN0BAABEf47TtGnTYjwOBAJuQMxXX33VbrjhhsQsGwAAQHQHTnfccUeMx+nSpbMCBQpYvXr1bMSIEYlZNgAAgOgOnM6dO5c0JQEAAEitOU579+61Q4cOJW5pAAAAUkvgdPDgQevevbtdfPHFVqhQIbvooouscOHC1q9fPzeWEwAAQGrmu6lu//79bmqVv/76y9q2bWvlypVzy1evXm2vvPKKzZkzx3788Udbvny5LViwwB555JGkLDcAAEDKDZyGDBniRgffsGGDq20KX9eoUSNr166dzZ4920aPHp0UZQUAAIiOwOmzzz6zcePGxQqaRM11w4cPtyZNmthTTz1lHTp0SOxyAgAARE+Ok8ZqqlChQrzrK1asaOnTp3eBEwAAQJoOnJQQvmnTpnjXb9y40QoWLJhY5QIAAIjewKlx48b25JNP2qlTp2KtO3nypA0YMMBuvvnmxC4fAABAdCaHX3PNNW5CXw1JULZsWTfdyu+//25jxoxxwdPEiROTtrQAAADREDgVK1bM5s+fbw899JAbt0lBkzflSsOGDd1cdSVKlEjKsgIAAETPlCulSpWymTNn2oEDB2zdunVuWenSpS1fvnxJVT4AAIDonatONGJ49erVE780AAAAqXGuOgAAgLSGwAkAAMAnAicAAACfCJwAAAB8InACAADwicAJAADAJwInAAAAnwicAAAAoiFwmjdvnjVr1syKFi3qpm757LPPYqzXtC4DBw60IkWKWLZs2axBgwbBEcs9+/fvt7Zt21ru3Lktb9681qVLFzty5EiMbZYvX261a9e2rFmzWvHixW348OH/yvsDAACpS7IGTkePHrUqVarYa6+9Fud6BTijR4+2sWPH2sKFCy1HjhzWuHFjO3HiRHAbBU2rVq2yOXPm2IwZM1wwdv/99wfXHzp0yBo1amQlS5a0JUuW2AsvvGCDBg2yN9544195jwAAII1PuZJYbrnlFneLi2qbXn75Zevfv7/dfvvtbtnEiROtUKFCrmaqVatW9vvvv9usWbNs8eLFds0117htXnnlFWvSpIm9+OKLribr/ffft1OnTtnbb79tmTNntgoVKtiyZcvspZdeihFgAQAARG2O08aNG23nzp2uec6TJ08eq1Gjhs2fP9891l81z3lBk2j79OnTuxoqb5s6deq4oMmjWqu1a9e6yYoBAACiosbpfBQ0iWqYQumxt05/CxYsGGN9xowZLV++fDG2KVWqVKx9eOs0YXG4kydPultocx8AAECKrXFKTsOGDXO1W95NCeUAAAApNnAqXLiw+7tr164Yy/XYW6e/u3fvjrH+zJkzrqdd6DZx7SP0NcL169fP/v777+Bt69atifjOAABAtEqxgZOa1xTYzJ07N0aTmXKXatas6R7r78GDB11vOc8333xj586dc7lQ3jbqaXf69OngNuqBV6ZMmTib6SRLlixueIPQGwAAQLIGThpvST3cdPMSwnV/y5Ytblynnj172jPPPGPTpk2zFStWWPv27V1PuTvuuMNtX65cObv55puta9eutmjRIvvpp5/s4Ycfdj3utJ20adPGJYZrfCcNWzB58mQbNWqU9erVKznfOgAAiELJmhz+yy+/WN26dYOPvWCmQ4cO9s4771ifPn3cWE8aNkA1S7Vq1XLDD2ggS4+GG1CwVL9+fdebrkWLFm7sJ49ylGbPnm3du3e3q6++2i6++GI3qCZDEQAAgEilC2jAJJyXmggVgCnfKamb7T5etCdJ9w+kBi2rF7DU4OCsV5K7CEBUyHtzjxRznk+xOU4AAAApDYETAACATwROAAAAPhE4AQAA+ETgBAAA4BOBEwAAgE8ETgAAAD4ROAEAAPhE4AQAAOATgRMAAIBPBE4AAAA+ETgBAAD4ROAEAADgE4ETAACATwROAAAAPhE4AQAA+ETgBAAA4BOBEwAAgE8ETgAAAD4ROAEAAPhE4AQAAOATgRMAAIBPBE4AAAA+ETgBAAD4ROAEAADgE4ETAACATwROAAAAPhE4AQAA+ETgBAAA4BOBEwAAgE8ETgAAAD4ROAEAAPhE4AQAAOATgRMAAIBPBE4AAAA+ETgBAAD4ROAEAADgE4ETAACATwROAAAAPhE4AQAA+ETgBAAA4BOBEwAAgE8ETgAAAD4ROAEAAPhE4AQAAOBTmgqcXnvtNbv00ksta9asVqNGDVu0aFFyFwkAAESRNBM4TZ482Xr16mVPPfWULV261KpUqWKNGze23bt3J3fRAABAlEgzgdNLL71kXbt2tU6dOln58uVt7Nixlj17dnv77beTu2gAACBKpInA6dSpU7ZkyRJr0KBBcFn69Ond4/nz5ydr2QAAQPTIaGnA3r177ezZs1aoUKEYy/V4zZo1sbY/efKku3n+/vtv9/fQoUNJXtZjRw4n+WsA0e7QoSyWGhw6ejy5iwBEhfRJfP71zu+BQOCC26aJwClSw4YNs8GDB8daXrx48WQpDwAAaVvff+VVDh8+bHny5DnvNmkicLr44ostQ4YMtmvXrhjL9bhw4cKxtu/Xr59LJPecO3fO9u/fb/nz57d06dL9K2VGyqCrEAXMW7dutdy5cyd3cQAkMb7zaVMgEHBBU9GiRS+4bZoInDJnzmxXX321zZ071+64445gMKTHDz/8cKzts2TJ4m6h8ubN+6+VFymPfkD5EQXSDr7zaU+eC9Q0panASVSD1KFDB7vmmmusevXq9vLLL9vRo0ddLzsAAAA/0kzgdM8999iePXts4MCBtnPnTqtatarNmjUrVsI4AACApfXASdQsF1fTHBAfNdlq0NTwplsAqRPfeVxIuoCfvncAAABIGwNgAgAAJAYCJwAAAJ8InAAAiMOgQYNcRyIgFIETkkTHjh3dYKG6aRyt0qVL25AhQ+zMmTPJXTQAKYB6N/fo0cMuu+wyl4itQSebNWvmxtcDUrI01asO/66bb77ZJkyY4Ob9+/LLL6179+6WKVMmNzJ7JDTPoAIwTcycVqTF94y0Y9OmTXbDDTe4gYVfeOEFq1Spkp0+fdq++uor9zsR1xyi0UrvS797SD34VUaS0VWkprQpWbKkdevWzRo0aGDTpk1zgVTv3r3tkksusRw5cliNGjXsu+++Cz7vnXfecT+o2rZ8+fJuP1u2bLFLL73UnnnmGWvfvr3lzJnT7VfbaHyu22+/3S2rXLmy/fLLL8F97du3z1q3bu1eK3v27O4HetKkSTHKedNNN9kjjzxiffr0sXz58rkyq4o+1MGDB+2+++6zAgUKuNGE69WrZ7/99luMbaZPn27XXnutZc2a1U3z07x58+C6hL7nxYsXW8OGDd3+NKrtjTfeaEuXLo3xugqwxo0bZ7feeqt7j+XKlbP58+fb+vXr3XvT611//fW2YcOGRPhfBf65hx56yB23ixYtshYtWtiVV15pFSpUcAMVL1iwwG3z0ksvue+rjl/VRuk5R44cifWdUbClY17ff12s7dixI8Zrvf32227f+k4VKVIkxpA0fr7Xofx+H19//XW77bbbXNmfffZZdyHUpUsXK1WqlGXLls3KlCljo0aNilVLr5kthg4d6sYX1Hvzaukff/xx99tUrFgxdzGK5EXghH+NfjBOnTrlfrh0Yv/www9t+fLldtddd7kfvHXr1gW3PXbsmD3//PM2fvx4W7VqlRUsWNAtHzlypLtS/fXXX61p06bWrl07F0jde++97gfs8ssvd4+9UTZOnDjhptv54osvbOXKlXb//fe75+gHO9S7777rfuQWLlxow4cPdz9Yc+bMCa5XGXfv3m0zZ860JUuWWLVq1ax+/fpuDkPR/hUoNWnSxJVNzQ0aod6T0PesuZM04v2PP/7oTihXXHGFew0tD/X000+7971s2TIrW7astWnTxh544AFXu6dAUp8HY5ghJdB3RoMPq2ZJ37lw3vRWqm0dPXq0+y7o+/nNN9+4i5tQ+s68+OKL9r///c/mzZvnLjZ0geJRAKPX0fd+xYoV7sJEaQN+v9fh/H4fdeGl3wO9ZufOnd0UXwp6PvroI1u9erUbiPmJJ56wKVOmxHie3uP27dvde1HgqPGkdEF00UUXud+mBx980H2vt23blsBPH4lC4zgBia1Dhw6B22+/3d0/d+5cYM6cOYEsWbIEOnbsGMiQIUPgr7/+irF9/fr1A/369XP3J0yYoKgnsGzZshjblCxZMnDvvfcGH+/YscNtN2DAgOCy+fPnu2VaF5+mTZsGHnvsseDjG2+8MVCrVq0Y21x77bWBvn37uvs//PBDIHfu3IETJ07E2Obyyy8PjBs3zt2vWbNmoG3btnG+3ubNmxP8nsOdPXs2kCtXrsD06dODy/S8/v37x/oM3nrrreCySZMmBbJmzXrefQP/hoULF7rjc+rUqRE976OPPgrkz58/+Nj7zqxfvz647LXXXgsUKlQo+Lho0aKBJ598Ms79+fleP/XUU4EqVapE/H3s2bPnBd9P9+7dAy1atIjxm6nfOO3TU6ZMmUDt2rWDj8+cORPIkSOH+z4j+ZDjhCQzY8YMV32uNn5dcakWpGXLlq6KXVXzodSUlT9//uBjJZSr2S1c6DJvuhxV54cv01WkmtxURa6qb13Z/fXXX67GS6+lJq349iuq0tc+RFX3aiIILZ8cP3482Pylmp6uXbvG+TnoqlPlSMh73rVrl/Xv398166k82o+usnVlHennoto3zfzOxKVITn7HXP76669t2LBhLt9Jx62arHQM6/j3vr/6q1rmuL63+qvaG9UgxcXP9zqc3++j5kQN99prr7lmQ22r19BvUXiPPTUphuY16ntbsWLF4OMMGTK48nrvEcmDwAlJpm7duq6qXAFB0aJFLWPGjDZ58mT35Ve1uP6GUpAV2qynXIFwoUmW3vq4lilQEyWeKpdAkzp7+RI9e/Z0P1rx7dfbj7cP/bjqBzk0Jym8WUHljY+en9D3rGYB5WnpPSinS3kaNWvWPG/5/XwuQHJR85aOx/MlgCt5XE1Uyo1UjpDye9Q8pjwhHfte4BTX99YLzM73nfT7vQ7n9/sY3gSpJno1IY4YMcJtnytXLvfbpOa3UHG9n/P9NiF5EDghyejHIzSfQK666ip3laYrptq1ayd5GX766SeXOK4cKNEPzh9//OESsP1S3oO6TivwU4J6XFTjo7ymTp06xVr3T96zyj9mzBiXRyFbt261vXv3RrQPICVRENS4cWNXA6NOGeFBhhK2dZGh76oCDa8GJjwf6EIUnOj7qu+lLuIS8r1OrO+jnqcOGkpw99BZI3qRHI5/lZqr2rZt6xKZp06dahs3bnSJ2qqSV4J1UlzdKsn7559/tt9//90lVqq6PRLqDairRPV4mT17trsa1v6efPLJYA8+JXGqt57+6nXUPKdE73/6nlV+Jb5qn7o61X4udCUNpHQKmnQxoQ4Un3zyieskoWNcyeD6rumCS038r7zyiv3555/uOzB27NiIX0dJ2gq+tF+9hjqQaJ9+v9eJ9X3U87RP9QDUhduAAQNcDz1EJwIn/OvUnVZBxGOPPea65eqHSz8iJUqUSPTXUj6Crix1hauu+cp70utFQlXjGoeqTp06rkZJgVCrVq1s8+bNwXwi7Vs9ZtRrR3kL6tYc2nMvoe/5rbfesgMHDrj3oN6AukL3ehgC0UqDXiqIUU2QvhPK41E3f9UOqXm/SpUqrleZLj607v3333cXGpFS05qa6VVLpPwhNf95PVn9fK8T6/uoC7Y777zT7rnnHjcUiZr7QmufEF3SKUM8uQsBAAAQDahxAgAA8InACQAAwCcCJwAAAJ8InAAAAHwicAIAAPCJwAkAAMAnAicAAACfCJwAAAB8InACkKZoxOjPPvssuYsBIEoROAFIVTRxa48ePdy0Hpq9vnjx4tasWTM3nQcA/FMZ//EeACCF0EStN9xwg+XNm9deeOEFq1SpkpssVpOrdu/e3dasWZMkr3vq1CnLnDlzkuwbQMpCjROAVEMTp6opThMst2jRwk3cqslde/XqZQsWLAhut3fvXmvevLllz57dzVyvyZk977zzjgu8QqlpT/v1DBo0yE3mPH78eCtVqpRlzZrVLdc2WhbfvgFEPwInAKnC/v37bdasWa5mKUeOHLHWhwZDgwcPtrvvvtuWL19uTZo0sbZt27rnR2L9+vX2ySef2NSpU23ZsmWJum8AKReBE4BUQYFMIBCwsmXLXnDbjh07WuvWra106dI2dOhQO3LkiKulirR5buLEiXbVVVdZ5cqVE3XfAFIuAicAqYKCJr9CAx3VTuXOndt2794d0euVLFnSChQokCT7BpByETgBSBWUT6QcIz8J4JkyZYrxWM87d+6cu58+ffpYQZgSzMPF1Rx4oX0DiH4ETgBShXz58lnjxo3ttddes6NHj8Zaf/DgQV/7US3S4cOHY+wjNIcJQNpG4AQg1VDQdPbsWatevbpL3F63bp39/vvvNnr0aKtZs6avfdSoUcP1iHviiSdsw4YN9sEHH7iedgAgBE4AUg0Nerl06VKrW7euPfbYY1axYkVr2LChG/zy9ddf911z9d5779mXX37pxoGaNGmSG34AACRdIJKMSgAAgDSMGicAAACfCJwAAAB8InACAADwicAJAADAJwInAAAAnwicAAAAfCJwAgAA8InACQAAwCcCJwAAAJ8InAAAAHwicAIAAPCJwAkAAMD8+X+KIAXXIPHBNgAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAJOCAYAAAAqFJGJAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjUsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvWftoOwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAR/lJREFUeJzt3QeYVNUdN/4DIiAoIChgQcWK2LBExViColhiQY01ir3EEsUWErEmajQ2YkElir4aoyZ2Y0FsUbGhKPaGQaOAiorYQNz3+Z3/f+bdXYqwd3Fh9vN5nnFn7r1z58zsLJ7vPa1JVVVVVQIAACigaZEnAwAABMECAAAoTLAAAAAKEywAAIDCBAsAAKAwwQIAAChMsAAAAAoTLAAAgMIECwAAoDDBAqhYp512WmrSpMlP8lq/+MUv8q3kkUceya/9z3/+s95e47333svnHDp06Bw/N8rRrl279POf/zy99dZb6ZBDDkkXXXRR+ilEmeN30VjsscceaZFFFknHH398+uyzz/Ln/vnnn9f769x8882pffv2afLkyYX+Pj755JM0L7nvvvvSwgsvnD7++OOGLgowhwQLYL4QlemoBJVuLVu2TEsuuWTq06dPGjRoUPryyy/r5XU+/PDDXOEaNWpUqiTnnntuDhNLLLFE6tatW7r11lvTTjvtlOZHyy23XI3vQvXb1ltv3aBle/XVV3OoPP3009Odd96ZOnTokHr37p3DRX2aNm1aOvXUU9NRRx2VK+G1911zzTU56EbwaNGiRf7M9t9///Tcc8+leV38DldcccV09tlnN3RRgDnUbE6fANCQzjjjjNS1a9c0derUNG7cuFyJO+aYY9IFF1yQK3Jrrrlm+diTTz45/e53v5vjYBGVwqiI9ejRY7af98ADD6S5bdlll03ffPNNWnDBBef4ubfccktaaqmlUrNmzfKV4LiiHuFsfhW/m+OOO2667RE2G9Lyyy+fRo4cmT/r+F7GdzTCXH2766670htvvJHDYnXx/dh5553zVf9NN900/f73v8/hIlq7ooXj2muvTWPHjk1LL710mpcdeuihucUn/hbjuwrMHwQLYL6yzTbbpPXWW6/8eMCAAemhhx5Kv/zlL9MOO+yQXnvttbTQQgvlfVGJjtvc9PXXX6dWrVql5s2bp7mt1FJT11BSsvjii6f5XVTcf/3rX6d5Tfx+omyhadOmcy3oRItEdGsrvVbJCSeckEPFhRdemINNddHCEdt/al999VVq3br1HD1nl112ya0xEYgPOOCAuVY2oH7pCgXM9zbffPM0cODA9N///jddf/31sxxjMWzYsLTxxhvnrinRhWSVVVbJV3VDtH787Gc/y/ej20ipe01pTEN0LVl99dXzFem4GhyBovTc2mMsqndLiWM6d+6cK1cRft5///0ax0TryH777Tfdc2ufc2ZjLF5//fW022675cAQoSre0x/+8Ify/jFjxqTDDz88rbzyynl/dM/51a9+lc9X27vvvpv3xVXueH8bbrhhuueee9Ls+O6779Kxxx6byxFXmeO9fvDBBzM89n//+1+uMHbq1Cl31VlttdXS1VdfnerLX/7yl/xZxXeitgijEQRj/EP4z3/+k9/zMsssk8vSpUuX/D7i6n910foQ34u42h/HRUvEjjvuWONzvO2229K2226bA0Ucs8IKK6Qzzzwzfw9qi0rzuuuum38niy22WA5K8bn8mG+//TaHh+hiVV181ldccUXacsstpwsVYYEFFsitALVbK2L8R3z/4m+ibdu2+T1GYJ6dsT21x8+U/uaiS9hee+2VFl100fz3VvqexwWAxx9/PK2//vo5hEULz3XXXTfdeTt27JhbH++4444f/TyAeYcWC6Ai7LPPPrkCH12SDj744Bke88orr+SKTVRYoktVVPzefvvt9MQTT+T9q666at5+yimn5C4mm2yySd6+0UYblc/x6aef5laTGKAbFcGoGM/Kn/70p1zROumkk9KECRPygOmoEMYYjlLLShEvvfRSLmd0j4oyR+XtnXfeyV1l4rXD008/nUaMGJH23HPPXKmMoDF48OAcWqICGAEijB8/Pr/XqFQeffTROYBE15kICDH4u2/fvrMsy0EHHZSDXVQo4zzRkrTddttNd1y8TgSW+FyOPPLIHETuvffedOCBB6ZJkybNsFJcW3SFm9Gg4whv8blG0DrxxBNz95+4il9dbNtqq61ypbdUwY/3HOEr3vMzzzyT/vrXv+aKeuyrfhU9vkNxJT0+5/h9RlCNrkXxOEQ4ilDVv3//XJaHH344f5/ifZ133nnlc0UlPSrwEWRjLEF8JhdffHH+Lr7wwguzHJMRwXbKlClpnXXWqbE9PsPvv/8+/y3MifisonthlOP5559PQ4YMyRX7P//5z6muIqittNJK6ayzzkpVVVXl7fH3tuuuu+bfdb9+/fLnFaEmAlaEy+pi2+23317nMgANoApgPnDNNddE7aTq2Wefnekxbdu2rVp77bXLj0899dT8nJILL7wwP/74449neo44fxwTr1fbZpttlvcNHjx4hvviVvLwww/nY5daaqmqSZMmlbfffPPNefvFF19c3rbssstW9evX70fPOWbMmOnKtummm1YtssgiVf/9739rPPeHH34o3//666+nO/eIESPyua677rrytmOOOSZv+89//lPe9uWXX1Z17dq1arnllquaNm1a1cyMGjUqP/c3v/lNje177bVX3h6/i5IDDzywaokllqj65JNPahy7xx575N/hjMpbXXxecc4Z3c4+++zycT179qxad911azz3mWeeme59z+j14jxNmjQpf66fffZZft555503y7J99dVX02079NBDq1q1alX17bff5sdTpkyp6tixY9Xqq69e9c0335SPu/vuu/NrnHLKKbN8jSFDhuTjRo8eXWP7sccem7e/8MILVbOj9PdxwAEH1Njet2/fqg4dOszye1dS+3dbOueee+4509/bY489Vt42YcKEqhYtWlQdd9xx0x1/1lln5ePHjx8/W+8HaHi6QgEVI7o2zWp2qNJV4Ohe8cMPP9TpNaKVI640z6599923xuDTuFobXWj+/e9/p6JiEPZjjz2WuxRFN57qqncBq94yElf6o9UlZt2JzyOuUJdEmaKLSqnrSukzjZaQ6A4TrRszU3o/0dJRXe3Wh6iL/utf/0rbb799vh+tDqVbzPD1xRdf1CjTzGywwQa5taD2LVplSnbfffd8dT9acEpuuumm/DuMLkwz+nxiPECUJVpconzRelA6JrpPRXe5UheqGSm1/oT4Lsa5okUpWkSiy1qImZmiteM3v/lNjTEz0boTM3b9WNez+P2FUotLSbSKhDkd7HzYYYfVeBzljdcona8uap+zpHv37uWWwBCtVdF1L7rg1VZ6f/PadLjAzAkWQMWI+fxnVamKimYMeI0uO9GFKbozRbeYOQkZMVh2TgZqR3eQ2hX+qNTPaHzDnCpVxmLcx6zEWIHojhNjB6JSHf35o0IXfeujIl8S4xGikldbdBEr7Z+Z2BeDlWNMQXW1zxdhKF73yiuvzGWofisFtqh0/5h4D9GlrPat+iD16I4TZYowESIoRNem6MrWpk2b8nHRlSm648S4kghSUZbNNtss7yt9PvG5Rdeg6G4U350YYxNT+Ma4i+qiq1R0GYuxCvEaca7SIPPSuUqf44w+6wgWs/qcq6vexSiU3tOcTr1cO5SWKvSzClA/JrpWzc5rlV5vRq9Ven8/1Vo0QHHGWAAVIfrDR8UtKu0zE1ed4wp/9HuPq8IxADYqnTH4O8ZmxODWH1Mf4yJqm1nFKQb8zk6ZfkyMCYhZhKL1oGfPnrnSG68ZwaquLTd1VXq9qGxHH/sZqT5lcBExgDqujkd4jPE3Tz31VA4R1ccOxGccg50nTpyYx8FExT7GRsQg6ggb1T+f+PyipSX6/d9///15woAYlxBjSdZee+0cmCKQRAU/xupEyIoWiWiBiXPX12cd40BCVMarD8SOsofRo0fP0VTJM/uO/VjFfkYD0n/s7+THXqu6UtiIEAnMHwQLoCL8n//zf/LP6E4zK3EFe4sttsi3WPsiBpfGDEoRNuKKd31fHY1VrmtXoGIAa/XKc1yxndHKzHHlOmbNmZnSvpdffnmWZYiB11GJP//882vMLFT7NeNqf6yNUFupC0/11oDaYl9UnKPbUfUr8bXPV5oxKiqltWc1mhuilSq6HEU5IkRGV6UIByVRCX/zzTfzIPXotlYS3apmJMJCrJ8Rt/jdRgU+PtcYtB7dpKILUSw+GC0aJTFYvrrS5xhlilBbXWyb1edcPUDEeddYY43y9miJiYp7lGVOB3DPSqkFo/b3ZXZbVuoq3l+pdQ2YP+gKBcz34opxTOkZ3S/23nvvmR4XV6VrK13ZjalSQ2m+/RlV9OsiptKs3jUlKvkfffRRrgRWr6zG1fSY6afk7rvvnm5a2tqiwhUV2JhZJ67Ez+wKcFQ2a18RjlmPal9xjmlSY0akmEGq+piD6LYUsx5F//iZKb2fWAW9upgFq7ooS8yuFOMsZhSIoqtUfYrXite88cYbczeomBWs+poKpSvo1T+fuB8zNFUXYyQijFUXv7cISaXvzozOFb/Tyy67rMbzYh2WmHUpZuYqPTdEN6tYh2VGM2nVni0puuPVXkU7urrFjGjR+ha/39oi+EUImtkUwDMTLTBRwY/Wvupqv6/6FuNjooUNmH9osQDmK1H5iivoMa1mTNEZoSKuLsdV3lh5e1YLyEX3lKgcRcUtjo++/FE5iu4kpQHLUVmMQc1R6YtKY1RCY6DwzPqM/5jotx/njvEDUd6oaEd3repT4saYjwgcW2+9dZ76M676x1Xn2uMVZiQq8nH+mHo0BllHOWP8RnT1iiltQ1Smo0UnukBFOIjg8OCDD5a71JTEKuVRAY+QEIOwo+xxJT+uHEcQiNaemYmAFgOn4/OMLmkx+Hn48OG5daa2c845J7cQxecan0OUKUJfdBmKcs0oANYWXZWqr1lSEmMkdtppp/LjqMD36tUrt05FwIsWjNpX/+NzjvUd4pxRiY73WrvPf7RqRCtX/H6ivLHwYqxZEb/T6FIW4j3H1f1oHYrPL1q/4nOvHepiauDojhXfieg6FZ9babrZCHCxhsasxHc8psuNzyq+09VFcIjvT7x+tJzE7z7KFMEzglX87ZTKOyfiOxq/t/gZwSj+juIzmVvibzOmUj7iiCPm2msAc0FDT0sFMCfTzZZuzZs3r+rcuXPVlltumadurT6l68ymmx0+fHjVjjvuWLXkkkvm58fPmBbzzTffrPG8O+64o6p79+5VzZo1qzHNZkz9utpqq82wfDObbvbGG2+sGjBgQJ5edKGFFqrabrvtppsaNpx//vl5atqYevPnP/951XPPPTdb082Gl19+OU8R2qZNm7x/lVVWqRo4cGB5f0yVuv/++1cttthiVQsvvHBVnz59ql5//fUZTnP7zjvvVO26665V7dq1q2rZsmXV+uuvn6dBnR0xderRRx+dpypt3bp11fbbb1/1/vvvTzclaYgpRI844oiqLl26VC244IL5d7nFFltUXXnllT/6OrOabjb21XbVVVflfTEtb/XpXUteffXVqt69e+fPJj6jgw8+uOrFF1+s8VnH1LhR3m7duuX3FtPibrDBBnn64OqeeOKJqg033DD/ruP7deKJJ1bdf//9+VzxnajupptuytMjx++8ffv2VXvvvXfVBx98MFuf9a233pqnwx07dux0+77//vs8Je0mm2ySyxmfb3wu8R2oPhVt6e+j9vTLpb+1+L5Vn5I3pgmO88XnuNtuu+WpYmc23eyMpnSOMsT3v7ba3/Nw+eWX5yl6Z/R3Dcy7msR/5kZgAeCnF+MWYmG4uKJN5YpubNFyEi0o0Q2w0sRg+FjA8cILL2zoogBzwBgLgAoSA5Nn1EWIyhLjOaIb1KWXXpqnWa4kMVtbDIwfMGBAQxcFmENaLAAqQIyNiIHWQ4cOzeMKon89APyUtFgAVIBYmO3II4/MA5BjIDIA/NS0WAAAAIVpsQAAAAoTLAAAgMIskDcbYrXSDz/8MC+WFQseAQBAY1BVVZUXGF1yySVnuVBqECxmQ4SKLl26NHQxAACgQbz//vtp6aWXnuUxgsVsiJaK0gfapk2bhi4OAAD8JCZNmpQvsJfqw7MiWMyGUvenCBWCBQAAjU2T2RgOYPA2AABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBcxDTjvttLwATfVbt27dyvuvvPLK9Itf/CIv1Bj7Pv/88xrPf+SRR6Z7fun27LPPTvd6b7/9dl5Js127dj9atrFjx6btttsutWrVKnXs2DGdcMIJ6fvvv6+ndw4AzO+svA3zmNVWWy09+OCD5cfNmv2/P9Ovv/46bb311vk2YMCA6Z670UYbpY8++qjGtoEDB6bhw4en9dZbr8b2qVOnpj333DNtsskm6cknn5xlmaZNm5ZDRefOnfOx8Rr77rtvWnDBBdNZZ51V4N0CAJVCsIB5TASJqMDPyDHHHFNumZiR5s2b13huhIc77rgjHXXUUbnVorqTTz45t4ZsscUWPxosHnjggfTqq6/mwNOpU6fUo0ePdOaZZ6aTTjopt7LE6wIAjZuuUDCPeeutt9KSSy6Zll9++bT33nvnLkh1deedd6ZPP/007b///jW2P/TQQ+mWW25Jl1566WydZ8SIEWmNNdbIoaKkT58+adKkSemVV16pc/kAgMohWMA8ZIMNNkhDhw5N9913X7r88svTmDFjclelL7/8sk7n+9vf/pYDwNJLL13eFkFjv/32y68TYzVmx7hx42qEilB6HPsAAHSFgnnINttsU76/5ppr5qCx7LLLpptvvjkdeOCBc3SuDz74IN1///35udUdfPDBaa+99kqbbrppvZUbAECLBczDYramlVdeOc/eNKeuueaa1KFDh7TDDjtM1w3qL3/5Sx7LEbcILF988UW+f/XVV8/wXDFuY/z48TW2lR7PbDwIANC4CBYwD5s8eXJ655130hJLLDFHz6uqqsrBojRzU+3xEqNGjSrfzjjjjDzlbNzv27fvDM/Xs2fPNHr06DRhwoTytmHDhuWuVN27d6/juwMAKolgAfOQ448/Pj366KPpvffeyzM1RUV/gQUWyNPClsYzRAAotWBEZT8eT5w4cbpWiRifcdBBB033GquuumpaffXVy7ellloqNW3aNN9fdNFF8zG33XZbjfUzttpqqxwg9tlnn/Tiiy/mLlYxq9QRRxyRWrRoMZc/FQBgfiBYwDwkxkVEiFhllVXSbrvtlrsyPfXUU2nxxRfP+wcPHpzWXnvtPE4ixDiJeByzP9UetB1rWlQPB3Miuka98cYb5ccRbu6+++78M1ovfv3rX+fWkGjtAAAITaqizwSzFFNqtm3bNle2ZncWHQAAaEz1YC0WAABAYYIFAABQmHUs5lPH3XtdQxcBqHDnb7NvQxcBgPmIFgsAAKAwwQIAAChMsAAAAAoTLAAAgMIECwAAoDDBAgAAKEywAAAAChMsAACAwgQLAACgMMECAAAoTLAAAADm72Bx2mmnpSZNmtS4devWrbz/22+/TUcccUTq0KFDWnjhhdMuu+ySxo8fX+McY8eOTdttt11q1apV6tixYzrhhBPS999/X+OYRx55JK2zzjqpRYsWacUVV0xDhw79yd4jAAA0Bg3eYrHaaquljz76qHx7/PHHy/uOPfbYdNddd6VbbrklPfroo+nDDz9MO++8c3n/tGnTcqiYMmVKevLJJ9O1116bQ8Mpp5xSPmbMmDH5mF69eqVRo0alY445Jh100EHp/vvv/8nfKwAAVKpmDV6AZs1S586dp9v+xRdfpL/97W/p73//e9p8883ztmuuuSatuuqq6amnnkobbrhheuCBB9Krr76aHnzwwdSpU6fUo0ePdOaZZ6aTTjopt4Y0b948DR48OHXt2jWdf/75+Rzx/AgvF154YerTp89P/n4BAKASNXiLxVtvvZWWXHLJtPzyy6e99947d20KI0eOTFOnTk29e/cuHxvdpJZZZpk0YsSI/Dh+rrHGGjlUlERYmDRpUnrllVfKx1Q/R+mY0jkAAID5vMVigw02yF2XVlllldwN6vTTT0+bbLJJevnll9O4ceNyi0O7du1qPCdCROwL8bN6qCjtL+2b1TERPr755pu00EILTVeu7777Lt9K4lgAAGAeDRbbbLNN+f6aa66Zg8ayyy6bbr755hlW+H8qZ599dg45AADAfNIVqrponVh55ZXT22+/ncddxKDszz//vMYxMStUaUxG/Kw9S1Tp8Y8d06ZNm5mGlwEDBuQxHqXb+++/X6/vEwAAKs08FSwmT56c3nnnnbTEEkukddddNy244IJp+PDh5f1vvPFGHoPRs2fP/Dh+jh49Ok2YMKF8zLBhw3Jo6N69e/mY6ucoHVM6x4zEtLRxjuo3AABgHg0Wxx9/fJ5G9r333svTxfbt2zctsMACac8990xt27ZNBx54YOrfv396+OGH82Du/fffPweCmBEqbLXVVjlA7LPPPunFF1/MU8iefPLJee2LCAfhsMMOS++++2468cQT0+uvv54uu+yy3NUqprIFAAAqYIzFBx98kEPEp59+mhZffPG08cYb56lk436IKWGbNm2aF8aLwdQxm1MEg5IIIXfffXc6/PDDc+Bo3bp16tevXzrjjDPKx8RUs/fcc08OEhdffHFaeuml05AhQ0w1CwAA9ahJVVVVVX2esBLFrFDRghLjLeaVblHH3XtdQxcBqHDnb7NvQxcBgPmoHjxPjbEAAADmT4IFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAUJhgAQAAFCZYAAAAhQkWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAUJhgAQAAFCZYAAAAhQkWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAUJhgAQAAFCZYAAAAhQkWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAUJhgAQAAFCZYAAAAhQkWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAUJhgAQAAFCZYAAAAhQkWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAUJhgAQAAFCZYAAAAhQkWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAUDnB4pxzzklNmjRJxxxzTHnbt99+m4444ojUoUOHtPDCC6dddtkljR8/vsbzxo4dm7bbbrvUqlWr1LFjx3TCCSek77//vsYxjzzySFpnnXVSixYt0oorrpiGDh36k70vAABoDOaJYPHss8+mK664Iq255po1th977LHprrvuSrfcckt69NFH04cffph23nnn8v5p06blUDFlypT05JNPpmuvvTaHhlNOOaV8zJgxY/IxvXr1SqNGjcrB5aCDDkr333//T/oeAQCgkjV4sJg8eXLae++901VXXZUWXXTR8vYvvvgi/e1vf0sXXHBB2nzzzdO6666brrnmmhwgnnrqqXzMAw88kF599dV0/fXXpx49eqRtttkmnXnmmenSSy/NYSMMHjw4de3aNZ1//vlp1VVXTUceeWTadddd04UXXthg7xkAACpNgweL6OoULQq9e/eusX3kyJFp6tSpNbZ369YtLbPMMmnEiBH5cfxcY401UqdOncrH9OnTJ02aNCm98sor5WNqnzuOKZ1jRr777rt8juo3AABg5pqlBvSPf/wjPf/887krVG3jxo1LzZs3T+3atauxPUJE7CsdUz1UlPaX9s3qmAgL33zzTVpooYWme+2zzz47nX766fXwDgEAoHFosBaL999/P/32t79NN9xwQ2rZsmWalwwYMCB3xSrdoqwAAMA8GCyiq9OECRPybE3NmjXLtxigPWjQoHw/WhVinMTnn39e43kxK1Tnzp3z/fhZe5ao0uMfO6ZNmzYzbK0IMXtU7K9+AwAA5sFgscUWW6TRo0fnmZpKt/XWWy8P5C7dX3DBBdPw4cPLz3njjTfy9LI9e/bMj+NnnCMCSsmwYcNyEOjevXv5mOrnKB1TOgcAADAfj7FYZJFF0uqrr15jW+vWrfOaFaXtBx54YOrfv39q3759DgtHHXVUDgQbbrhh3r/VVlvlALHPPvukc889N4+nOPnkk/OA8Gh1CIcddli65JJL0oknnpgOOOCA9NBDD6Wbb7453XPPPQ3wrgEAoDI16ODtHxNTwjZt2jQvjBczNcVsTpdddll5/wILLJDuvvvudPjhh+fAEcGkX79+6YwzzigfE1PNRoiINTEuvvjitPTSS6chQ4bkcwEAAPWjSVVVVVU9natixQxSbdu2zQO555XxFsfde11DFwGocOdvs29DFwGA+age3ODrWAAAAPM/wQIAAChMsAAAAAoTLAAAgMIECwAAoDDBAgAAKEywAAAAChMsAACAwgQLAACgMMECAAAoTLAAAAAKEywAAIDCBAsAAKAwwQIAAChMsAAAAAoTLAAAgMIECwAAoDDBAgAAKEywAAAAChMsAACAwgQLAACgMMECAAAoTLAAAAAKEywAAIDCBAsAAKAwwQIAAChMsAAAAAoTLAAAgMIECwAAoDDBAgAAKEywAAAAChMsAACAhgkW77//fvrggw/Kj5955pl0zDHHpCuvvLJ4iQAAgMYRLPbaa6/08MMP5/vjxo1LW265ZQ4Xf/jDH9IZZ5xR32UEAAAqMVi8/PLLaf3118/3b7755rT66qunJ598Mt1www1p6NCh9V1GAACgEoPF1KlTU4sWLfL9Bx98MO2www75frdu3dJHH31UvyUEAAAqM1isttpqafDgwek///lPGjZsWNp6663z9g8//DB16NChvssIAABUYrD485//nK644or0i1/8Iu25555prbXWytvvvPPOchcpAACg8WhWlydFoPjkk0/SpEmT0qKLLlrefsghh6RWrVrVZ/kAAIBKXseiqqoqjRw5MrdcfPnll3lb8+bNBQsAAGiE6tRi8d///jePqxg7dmz67rvv8nSziyyySO4iFY9j/AUAANB41KnF4re//W1ab7310meffZYWWmih8va+ffum4cOH12f5AACASm2xiNmgYt2K6PpU3XLLLZf+97//1VfZAACASm6x+OGHH9K0adOm2/7BBx/kLlEAAEDjUqdgsdVWW6WLLrqo/LhJkyZp8uTJ6dRTT03bbrttfZYPAACo1K5Q559/furTp0/q3r17+vbbb9Nee+2V3nrrrbTYYoulG2+8sf5LCQAAVF6wWHrppdOLL76YbrrppvwzWisOPPDAtPfee9cYzA0AADQOdQoWjz32WNpoo41ykIhbyffff5/3bbrppvVZRgAAoBLHWPTq1StNnDhxuu1ffPFF3gcAADQuTeu66nYM2K7t008/Ta1bt66PcgEAAJXaFWrnnXfOPyNU7LfffqlFixblfTH97EsvvZS7SAEAAI3LHAWLtm3bllssYr2K6gO1Y7G8DTfcMB188MH1X0oAAKBygsU111xTXmH7+OOP1+0JAACo+6xQsRAeAABAocHb48ePT/vss09acsklU7NmzdICCyxQ4wYAADQudWqxiIHbY8eOTQMHDkxLLLHEDGeIAgAAGo86BYvHH388/ec//0k9evSo/xIBAACNoytUly5d8sxQAAAAdQ4WF110Ufrd736X3nvvPZ8iAABQt65Qu+++e/r666/TCiuskFq1apUWXHDBGvsnTpxYX+UDAAAqNVhEiwUAAEChYNGvX7+6PA0AAKhQdRpjEd5555108sknpz333DNNmDAhb7v33nvTK6+8Up/lAwAAKjVYPProo2mNNdZITz/9dLr11lvT5MmT8/YXX3zRqtwAANAI1SlYxIxQf/zjH9OwYcNS8+bNy9s333zz9NRTT9Vn+QAAgEoNFqNHj059+/adbnvHjh3TJ598Uh/lAgAAKj1YtGvXLn300UfTbX/hhRfSUkstVR/lAgAAKj1Y7LHHHumkk05K48aNS02aNEk//PBDeuKJJ9Lxxx+f9t133/ovJQAAUHnB4qyzzkrdunVLXbp0yQO3u3fvnjbddNO00UYb5ZmiAACAxqVO61jEgO2rrroqDRw4ML388ss5XKy99tpppZVWqv8SAgAAlRksSpZZZpl8AwAAGrfZDhb9+/dPZ555ZmrdunW+PysXXHBBfZQNAACotGARMz5NnTq1fH9mYjA3AADQuMx2sHj44YdneB8AAKBOs0IBAADUqcVi5513nt1D06233jrbxwIAAI0oWLRt23bulgQAAKj8YHHNNdfM3ZIAAACNY4zFt99+m+6888705ZdfTrdv0qRJed93331Xn+UDAAAqLVhcccUV6eKLL06LLLLIdPvatGmTBg0alFfkBgAAGpc5ChY33HBDOuaYY2a6P/Zdd9119VEuAACgUoPFW2+9ldZaa62Z7l9zzTXzMQAAQOMyR8Hi+++/Tx9//PFM98e+OGZ2XX755TmMRDequPXs2TPde++9NcZ0HHHEEalDhw5p4YUXTrvssksaP358jXOMHTs2bbfddqlVq1apY8eO6YQTTpiuDI888khaZ511UosWLdKKK66Yhg4dOidvGwAAqM9gsdpqq6UHH3xwpvsfeOCBfMzsWnrppdM555yTRo4cmZ577rm0+eabpx133DG98soref+xxx6b7rrrrnTLLbekRx99NH344Yc11tOYNm1aDhVTpkxJTz75ZLr22mtzaDjllFPKx4wZMyYf06tXrzRq1KjcXeuggw5K999//5y8dQAAYBaaVFVVVaXZdOWVV6b+/funf/zjH+mXv/xljX0RAPbcc890wQUXpEMOOSTVVfv27dN5552Xdt1117T44ounv//97/l+eP3119Oqq66aRowYkTbccMPcuhHliMDRqVOnfMzgwYPTSSedlFtPmjdvnu/fc8896eWXXy6/xh577JE+//zzdN99981WmWLGq1jH44svvsgtK/OC4+41lgWYu87fZt+GLgIADWxO6sFz1GIRgWGnnXZKO+ywQ+revXvq27dvvkVlP7Zvv/32dQ4V0foQgeWrr77KXaKiFWPq1Kmpd+/e5WO6deuWlllmmRwsQvxcY401yqEi9OnTJ38ApVaPOKb6OUrHlM4xIzFlbpyj+g0AAKinYBGuv/76HABWXnnl9Oabb6Y33ngjrbLKKunGG2/Mtzk1evToPH4ixj8cdthh6bbbbsuhZdy4cbnFoV27djWOjxAR+0L8rB4qSvtL+2Z1TISFb775ZoZlOvvss3MyK926dOkyx+8LAAAak9leebu63XbbLd/qQ4SSGPsQzSv//Oc/U79+/fJ4ioY0YMCA3OWrJEKIcAEAAPUcLOpTtErETE1h3XXXTc8++2xehG/33XfPg7JjLET1VouYFapz5875fvx85plnapyvNGtU9WNqzyQVj6OP2EILLTTDMkXrSdwAAIC51BVqbvvhhx/yGIcIGQsuuGAaPnx4eV90u4rpZWMMRoif0ZVqwoQJ5WOGDRuWQ0N0pyodU/0cpWNK5wAAAObzFovocrTNNtvkAdlffvllngEq1pyIqWBjbMOBBx6YuyTFTFERFo466qgcCGJGqLDVVlvlALHPPvukc889N4+nOPnkk/PaF6UWhxi3cckll6QTTzwxHXDAAemhhx5KN998c54pCgAAqIBgES0N++67b/roo49ykIjF8iJUbLnllnn/hRdemJo2bZoXxotWjJjN6bLLLis/f4EFFkh33313Ovzww3PgaN26dR6jccYZZ5SP6dq1aw4RsSZGdLGKtTOGDBmSzwUAADTAOha1vf322+mdd95Jm266aR6vEKdq0qRJqjTWsQAaI+tYADBpbq1jUfLpp5/mtSFiytltt902tziE6Lp03HHH1a3UAADAfKtOwSK6FTVr1iwPpG7VqlV5e8zkNLurWQMAAI18jMUDDzyQx0LEeIXqVlpppfTf//63vsoGAABUcovFV199VaOlomTixInWfwAAgEaoTsFik002Sddd9/8GD8eA7Vh/IqZ87dWrV32WDwAAqNSuUBEgtthii/Tcc8/l1bFjjYhXXnklt1g88cQT9V9KAACg8losVl999fTmm2+mjTfeOO244465a9TOO++cXnjhhbTCCivUfykBAIDKXCAv5rP9wx/+UL+lAQAAKjtYvPTSS7N90lhBGwAAaDxmO1j06NEjD9Kuvbp2aeHu6tumTZtW3+UEAAAqYYzFmDFj0rvvvpt//utf/0pdu3ZNl112WRo1alS+xf0YXxH7AACAxmW2WyyWXXbZ8v1f/epXadCgQWnbbbet0f2pS5cuaeDAgWmnnXaq/5ICAACVNSvU6NGjc4tFbbHt1VdfrY9yAQAAlR4sVl111XT22WfnNSxK4n5si30AAEDjUqfpZgcPHpy23377tPTSS5dngIpZo2IA91133VXfZQQAACoxWKy//vp5IPcNN9yQXn/99bxt9913T3vttVdq3bp1fZcRAACo1AXyIkAccsgh9VsaAACg8YyxAAAAqE6wAAAAChMsAACAwgQLAACg4YLF559/noYMGZIGDBiQJk6cmLc9//zz6X//+1/xUgEAAJU/K1SsWdG7d+/Utm3b9N5776WDDz44tW/fPt16661p7Nix6brrrqv/kgIAAJXVYtG/f/+03377pbfeeiu1bNmyvH3bbbdNjz32WH2WDwAAqNRg8eyzz6ZDDz10uu1LLbVUGjduXH2UCwAAqPRg0aJFizRp0qTptr/55ptp8cUXr49yAQAAlR4sdthhh3TGGWekqVOn5sdNmjTJYytOOumktMsuu9R3GQEAgEoMFueff36aPHly6tixY/rmm2/SZpttllZcccW0yCKLpD/96U/1X0oAAKDyZoWK2aCGDRuWHn/88TxDVISMddZZJ88UBQAAND51ChYlG2+8cb4BAACN22wHi0GDBs32SY8++ui6lgcAAKjkYHHhhRfWePzxxx+nr7/+OrVr1668EnerVq3yuAvBAgAAGpfZHrw9ZsyY8i0GaPfo0SO99tpraeLEifkW92OcxZlnnjl3SwwAAFTGrFADBw5Mf/3rX9Mqq6xS3hb3o1Xj5JNPrs/yAQAAlRosPvroo/T9999Pt33atGlp/Pjx9VEuAACg0oPFFltskQ499ND0/PPPl7eNHDkyHX744aacBQCARqhOweLqq69OnTt3Tuutt15q0aJFvq2//vqpU6dOaciQIfVfSgAAoPLWsVh88cXTv//97/Tmm2+m119/PW/r1q1bWnnlleu7fAAAQKUvkBdBQpgAAADqHCw++OCDdOedd6axY8emKVOm1Nh3wQUX1EfZAACASg4Ww4cPTzvssENafvnlc1eo1VdfPb333nupqqoqr2UBAAA0LnUavD1gwIB0/PHHp9GjR6eWLVumf/3rX+n9999Pm222WfrVr35V/6UEAAAqL1jEKtv77rtvvt+sWbP0zTffpIUXXjidccYZ6c9//nN9lxEAAKjEYNG6devyuIolllgivfPOO+V9n3zySf2VDgAAqNwxFhtuuGF6/PHH06qrrpq23XbbdNxxx+VuUbfeemveBwAANC51ChYx69PkyZPz/dNPPz3fv+mmm9JKK61kRigAAGiE6hQsYjao6t2iBg8eXJ9lAgAAGsMYCwAAgDq1WCy66KKpSZMms3XsxIkTZ/e0AABAYwoWF110Ufn+p59+mv74xz+mPn36pJ49e+ZtI0aMSPfff38aOHDg3CkpAAAw/weLfv36le/vsssuec2KI488srzt6KOPTpdcckl68MEH07HHHlv/JQUAACprjEW0TGy99dbTbY9tESwAAIDGpU7BokOHDumOO+6Ybntsi30AAEDjUqfpZmPtioMOOig98sgjaYMNNsjbnn766XTfffelq666qr7LCAAAVGKw2G+//fKq24MGDcqrbYd4HKtxl4IGAADQeNQpWIQIEDfccEP9lgYAAKjsYDFp0qTUpk2b8v1ZKR0HAAA0DnO0QN5HH32UOnbsmNq1azfDxfKqqqry9mnTptV3OQEAgEoIFg899FBq3759vv/www/PzTIBAACVGiw222yz8v2uXbumLl26TNdqES0W77//fv2WEAAAqMx1LCJYfPzxx9NtnzhxYt4HAAA0LnUKFqWxFLVNnjw5tWzZsj7KBQAAVOp0s/37988/I1QMHDgwtWrVqrwvBmzHInk9evSo/1ICAACVEyxeeOGFcovF6NGjU/Pmzcv74v5aa62Vjj/++PovJQAAUDnBojQb1P77758uvvhi61UAAAB1X3n7mmuuqcvTAACAClWnYPHVV1+lc845Jw0fPjxNmDAh/fDDDzX2v/vuu/VVPgAAoFKDxUEHHZQeffTRtM8++6QlllhihjNEAQAAjUedgsW9996b7rnnnvTzn/+8/ksEAAA0jnUsFl100dS+ffv6Lw0AANB4gsWZZ56ZTjnllPT111/Xf4kAAIDG0RXq/PPPT++8807q1KlTWm655dKCCy5YY//zzz9fX+UDAAAqNVjstNNO9V8SAACgcQWLU089tf5LAgAANK4xFgAAAIVbLKZNm5YuvPDCdPPNN6exY8emKVOm1Ng/ceLEupwWAABoTC0Wp59+errgggvS7rvvnr744ovUv3//tPPOO6emTZum0047rf5LCQAAVF6wuOGGG9JVV12VjjvuuNSsWbO05557piFDhuQpaJ966qn6LyUAAFB5wWLcuHFpjTXWyPcXXnjh3GoRfvnLX+YVuQEAgMalTsFi6aWXTh999FG+v8IKK6QHHngg33/22WdTixYt6reEAABAZQaLvn37puHDh+f7Rx11VBo4cGBaaaWV0r777psOOOCA+i4jAABQibNCnXPOOeX7MYB7mWWWSSNGjMjhYvvtt6/P8gEAAI1lHYuePXvmmaHmNFScffbZ6Wc/+1laZJFFUseOHfOK3m+88UaNY7799tt0xBFHpA4dOuTxHLvssksaP358jWNiytvtttsutWrVKp/nhBNOSN9//32NYx555JG0zjrr5K5aK664Yho6dGiBdwwAABRusbjuuutmuT+6RM2ORx99NIeGCBcRBH7/+9+nrbbaKr366qupdevW+Zhjjz02Dwi/5ZZbUtu2bdORRx6Zp7Z94oknymtqRKjo3LlzevLJJ/PYj3j9BRdcMJ111ln5mDFjxuRjDjvssDyjVXTjOuigg9ISSyyR+vTpU5ePAAAAqKZJVVVVVZpDiy66aI3HU6dOTV9//XVq3rx5bjWo6wJ5H3/8cW5xiMCx6aab5tmmFl988fT3v/897brrrvmY119/Pa266qq569WGG26Y7r333jwb1Ycffpg6deqUjxk8eHA66aST8vmiTHE/wsnLL79cfq099tgjff755+m+++770XJNmjQph5ooT5s2bdK84Lh7Zx3uAIo6f5vZu0gEQOWak3pwnbpCffbZZzVukydPzl2YNt5443TjjTfWtdzlaWvbt2+ff44cOTKHlt69e5eP6datW3lMR4ifMfVtKVSEaIWID+GVV14pH1P9HKVjSueo7bvvvsvPr34DACrbY489lrt1L7nkkqlJkybp9ttvr7E/6jvRcyJmx1xooYVS9+7d88XM2qJ+sfnmm+feF1ERi4ul33zzTXn/888/n7bccsvUrl273NX7kEMOyeeelbgOHOuFRW+LeO2o17z11lv1+O5hHhljEWLgdgzq/u1vf1un5//www/pmGOOST//+c/T6quvXl4vI1oc4g+vuggRsa90TPVQUdpf2jerYyIwVP9Drz72I5JZ6dalS5c6vScAYP7x1VdfpbXWWitdeumlM9wf40mjp8P111+fXnvttVxviaBx55131ggVW2+9de7a/cwzz+Sp+OOYpk3/vypX9LCIUBDjPZ9++ul8vrgQut9++82ybOeee24aNGhQDjLxvAgtcZE0xqLCfD3GYqYna9Ys/8HURYy1iK5Kjz/+eGpoAwYMyP94lEQAES4AoLJts802+TYzMZazX79+6Re/+EV+HC0NV1xxRQ4QO+ywQ3ls6NFHH51+97vflZ+3yiqrlO/ffffdeRxohJdS2IiwsOaaa6a33347B44ZtVZcdNFF6eSTT0477rhjebxrXCSNVpXo3g3zbYtFJPPqtzvuuCP/Ufz617/OLQ5zKpJ8/KE9/PDDuXmxJAZkT5kyJY+FqC5mhYp9pWNqzxJVevxjx0TzZDQn1hYzR8W+6jcAoHHbaKONcr3nf//7X67sR73lzTffzK0TYcKECbk1IcaLxrFR8d9ss81qXDSN7tbRG6MUKkKpLjKzi6sxCU30vqjerTt6VGywwQYz7dYN802wiGlhq99ilqbTTjstp+2rr756ts8Tf5QRKm677bb00EMPpa5du9bYv+666+ZUX1qML8RYjpheNqa4DfFz9OjR+Y+5ZNiwYTkMRN/H0jHVz1E6pnQOAIAf89e//jXXLeIiaISD6PIULQ8xhiK8++67+WfUiQ4++ODczSmmut9iiy3K4yFi7EWEhPPOOy9fPI2xqqXWjZjZckZKXbtn1K27tA/m265QMR6iPkT3p5jxKVo8Yi2L0h9HpPBI7/HzwAMPzN2SYkB3hIVY6TsCQcwIFeIqQfyR77PPPrn/YZwjmgrj3NHyEGKa2UsuuSSdeOKJeWXwCDE333xznikKAGB2g8VTTz2VWy2WXXbZPNg76hsx2DtaE0r1o0MPPTTtv//++f7aa6+dL27GhdcYw7naaqula6+9Ntdtouv1AgsskLtORUio3ooBjW6MxSeffJITe127Cl1++eX5Z6mvYsk111xTHsR04YUX5j+0WBgvmg9joNJll11WPjb+IKMb1eGHH54DRwxmiv6PZ5xxRvmYaAmJEBH9Hi+++OJ8pWHIkCHWsAAAZktM9hLrbUUvi1gbK0RPjVGjRqW//OUvOVjEjE2h1GOiJKbJj94WJXvttVe+RbfsqLfEDFQXXHBBWn755Wf42qWu3XF86TVKj3v06DFX3i/8JMEixjv84Q9/SDfddFNuvgux1kQk84EDB+Z1LGbX7Cyh0bJly9zMOLMZGkJcNfj3v/89y/NEeHnhhRdmu2wAACUx/X3carcqxAXOUkvFcsstl1svott2dTEOY0aDwktdm6I1I+o7MQXtjMQF0ggX0fJRChIxsUyM54gLqzBfBotY+C5aBWLQ0t57750TeIiVsqN5MMYtxMCjl156KTcVRtMeAMD8INaSiJmZqg+ajhaJ6I4da2jFQOwTTjghd9eOi5qxoG/MzhStDSFaHmL/qaeemqetjRAQ3Z5icd9//vOf5fNG9+wY3L3wwgvnulM8J6bsrz69fqzbFV2n+vbtm88bU9v+8Y9/zNP7R9CIi7kRYmKsK8yXwSK6F0XXp3feeWe6AUSxL8Y7xFiHBx54IM+1DAAwv3juuedSr169yo9LU89HF+uhQ4emf/zjH3lcRFxcjYutES7+9Kc/5bGcJREAYm2J6H4dx0TAiPCwwgorlI+J6WkjfESQiQARU9ZG/am6aPUoLRwcYpxorLMRU9xG75FYlDgGh0dLB8wrmlTNTn+k/1808cWXf2ZjE+ILvu222+Y/lrg1xqXMfyrH3XtdQxcBqHDnb7NvQxcBgPmoHjxH0w/ENGgxm8HMxIrZ0fewkkIFAADw4+YoWCy22GLpvffem+n+6IsYi8IAAACNyxyNsYguUDEjVPQVjLEW1cVUsDGQKBaLAYBKNeHyExu6CEAj0PHwc1PFD95eb7318owEsSBMDDiKIRqvvfZaXlsiwkXMjgAAADQucxQsYmG5ESNGpN/85jd5VoTSuO+YBi3mXo7p02I6NgAAoHGZ4wXyYu7ke++9Ny+O99Zbb+VtK664Yp7jGQAAaJzmOFiULLroomn99dev39IAAACVPysUAADAjAgWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAUJhgAQAAFCZYAAAAhQkWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAUJhgAQAAFCZYAAAAhQkWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAUJhgAQAAFCZYAAAAhQkWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAUJhgAQAAFCZYAAAAhQkWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAUJhgAQAAFCZYAAAAhQkWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgAAQGGCBQAAMH8Hi8ceeyxtv/32ackll0xNmjRJt99+e439VVVV6ZRTTklLLLFEWmihhVLv3r3TW2+9VeOYiRMnpr333ju1adMmtWvXLh144IFp8uTJNY556aWX0iabbJJatmyZunTpks4999yf5P0BAEBj0aDB4quvvkprrbVWuvTSS2e4PwLAoEGD0uDBg9PTTz+dWrdunfr06ZO+/fbb8jERKl555ZU0bNiwdPfdd+ewcsghh5T3T5o0KW211VZp2WWXTSNHjkznnXdeOu2009KVV175k7xHAABoDJo15Itvs802+TYj0Vpx0UUXpZNPPjntuOOOedt1112XOnXqlFs29thjj/Taa6+l++67Lz377LNpvfXWy8f89a9/Tdtuu236y1/+kltCbrjhhjRlypR09dVXp+bNm6fVVlstjRo1Kl1wwQU1AggAAFCBYyzGjBmTxo0bl7s/lbRt2zZtsMEGacSIEflx/IzuT6VQEeL4pk2b5haO0jGbbrppDhUl0erxxhtvpM8+++wnfU8AAFCpGrTFYlYiVIRooaguHpf2xc+OHTvW2N+sWbPUvn37Gsd07dp1unOU9i266KLTvfZ3332Xb9W7UwEAAPNhi0VDOvvss3PrSOkWA74BAID5MFh07tw5/xw/fnyN7fG4tC9+Tpgwocb+77//Ps8UVf2YGZ2j+mvUNmDAgPTFF1+Ub++//349vjMAAKg882ywiO5LUfEfPnx4jS5JMXaiZ8+e+XH8/Pzzz/NsTyUPPfRQ+uGHH/JYjNIxMVPU1KlTy8fEDFKrrLLKDLtBhRYtWuTpa6vfAACAeTRYxHoTMUNT3EoDtuP+2LFj87oWxxxzTPrjH/+Y7rzzzjR69Oi077775pmedtppp3z8qquumrbeeut08MEHp2eeeSY98cQT6cgjj8wzRsVxYa+99soDt2N9i5iW9qabbkoXX3xx6t+/f0O+dQAAqCgNOnj7ueeeS7169So/LlX2+/Xrl4YOHZpOPPHEvNZFTAsbLRMbb7xxnl42FrorielkI0xsscUWeTaoXXbZJa99URJjJB544IF0xBFHpHXXXTcttthiedE9U80CAED9aVIVC0YwS9EFKwJKjLeYV7pFHXfvdQ1dBKDCnb/Nvg1dhHnShMtPbOgiAI1Ax8PPTfNbPXieHWMBAADMPwQLAACgMMECAAAoTLAAAAAKEywAAIDCBAsAAKAwwQIAAChMsAAAAAoTLAAAgMIECwAAoDDBAgAAKEywAAAAChMsAACAwgQLAACgMMECAAAoTLAAAAAKEywAAIDCBAsAAKAwwQIAAChMsAAAAAoTLAAAgMIECwAAoDDBAgAAKEywAAAAChMsAACAwgQLAACgMMECAAAoTLAAAAAKEywAAIDCBAsAAKAwwQIAAChMsAAAAAoTLAAAgMIECwAAoDDBAgAAKEywAAAAChMsAACAwgQLAACgMMECAAAoTLAAAAAKEywAAIDCBAsAAKAwwQIAAChMsAAAAAoTLAAAgMIECwAAoDDBAgAAKEywAAAAChMsAACAwgQLAACgMMECAAAoTLAAAAAKEywAAIDCBAsAAKAwwQIAAChMsAAAAAoTLAAAgMIECwAAoDDBAgAAKEywAAAAChMsAACAwgQLAACgMMECAAAoTLAAAAAKEywAAIDCBAsAAKAwwQIAAChMsAAAAAoTLAAAgMIECwAAoDDBAgAAKEywAAAAChMsAACAwgQLAACgMMECAAAoTLAAAAAKEywAAIDCBAsAAKAwwQIAAChMsAAAAAoTLAAAgMIECwAAoLBGFSwuvfTStNxyy6WWLVumDTbYID3zzDMNXSQAAKgIjSZY3HTTTal///7p1FNPTc8//3xaa621Up8+fdKECRMaumgAADDfazTB4oILLkgHH3xw2n///VP37t3T4MGDU6tWrdLVV1/d0EUDAID5XqMIFlOmTEkjR45MvXv3Lm9r2rRpfjxixIgGLRsAAFSCZqkR+OSTT9K0adNSp06damyPx6+//vp0x3/33Xf5VvLFF1/kn5MmTUrziu++/qahiwBUuHnp37x5yZff/L//PwDMLS3nkX+DS/8vqKqq+tFjG0WwmFNnn312Ov3006fb3qVLlwYpD0BDuDQd1tBFAGi8jhuU5iVffvllatu27SyPaRTBYrHFFksLLLBAGj9+fI3t8bhz587THT9gwIA80Lvkhx9+SBMnTkwdOnRITZo0+UnKDPV9tSGC8fvvv5/atGnT0MUBaFT8G8z8LFoqIlQsueSSP3psowgWzZs3T+uuu24aPnx42mmnncphIR4feeSR0x3fokWLfKuuXbt2P1l5YW6J/6H5nxpAw/BvMPOrH2upaFTBIkQLRL9+/dJ6662X1l9//XTRRRelr776Ks8SBQAAFNNogsXuu++ePv7443TKKaekcePGpR49eqT77rtvugHdAADAnGs0wSJEt6cZdX2CShdd+2JxyNpd/ACY+/wbTGPRpGp25o4CAABo7AvkAQAAc5dgAQAAFCZYAAAAhQkWUOEuvfTStNxyy6WWLVumDTbYID3zzDMNXSSARuGxxx5L22+/fV5YLBbYvf322xu6SDBXCRZQwW666aa8hkvMRvL888+ntdZaK/Xp0ydNmDChoYsGUPFivaz4dzcu8EBjYFYoqGDRQvGzn/0sXXLJJeUV57t06ZKOOuqo9Lvf/a6hiwfQaESLxW233ZZ22mmnhi4KzDVaLKBCTZkyJY0cOTL17t27vK1p06b58YgRIxq0bABA5REsoEJ98sknadq0adOtLh+PY/V5AID6JFgAAACFCRZQoRZbbLG0wAILpPHjx9fYHo87d+7cYOUCACqTYAEVqnnz5mnddddNw4cPL2+LwdvxuGfPng1aNgCg8jRr6AIAc09MNduvX7+03nrrpfXXXz9ddNFFefrD/fffv6GLBlDxJk+enN5+++3y4zFjxqRRo0al9u3bp2WWWaZBywZzg+lmocLFVLPnnXdeHrDdo0ePNGjQoDwNLQBz1yOPPJJ69eo13fa44DN06NAGKRPMTYIFAABQmDEWAABAYYIFAABQmGABAAAUJlgAAACFCRYAAEBhggUAAFCYYAEAABQmWAAAAIUJFgA0mCZNmqTbb7+9oYsBQD0QLACYa8aNG5eOOuqotPzyy6cWLVqkLl26pO233z4NHz68oYsGQD1rVt8nBIDw3nvvpZ///OepXbt26bzzzktrrLFGmjp1arr//vvTEUcckV5//fW58rpTpkxJzZs3nyvnBmDmtFgAMFf85je/yV2dnnnmmbTLLruklVdeOa222mqpf//+6amnniof98knn6S+ffumVq1apZVWWindeeed5X1Dhw7NwaS66DoV5y057bTTUo8ePdKQIUNS165dU8uWLfP2OCa2zezcANQvwQKAejdx4sR033335ZaJ1q1bT7e/elg4/fTT02677ZZeeumltO2226a99947P39OvP322+lf//pXuvXWW9OoUaPq9dwAzB7BAoB6FxX9qqqq1K1btx89dr/99kt77rlnWnHFFdNZZ52VJk+enFs55rT703XXXZfWXnvttOaaa9bruQGYPYIFAPUuQsXsqh4EonWjTZs2acKECXP0essuu2xafPHF58q5AZg9ggUA9S7GM8QYh9kZoL3gggvWeBzP++GHH/L9pk2bThdSYgB4bTPqbvVj5wagfgkWANS79u3bpz59+qRLL700ffXVV9Pt//zzz2frPNEK8eWXX9Y4R/UxFADMOwQLAOaKCBXTpk1L66+/fh5Y/dZbb6XXXnstDRo0KPXs2XO2zrHBBhvkGZ1+//vfp3feeSf9/e9/zzNFATDvESwAmCtiUbznn38+9erVKx133HFp9dVXT1tuuWVeHO/yyy+f7ZaP66+/Pv373//O62DceOONeXpZAOY9TarmZIQdAADADGixAAAAChMsAACAwgQLAACgMMECAAAoTLAAAAAKEywAAIDCBAsAAKAwwQIAAChMsAAAAAoTLAAAgMIECwAAoDDBAgAASEX9X2Snx4uctILuAAAAAElFTkSuQmCC",
       "text/plain": [
-       "<Figure size 600x400 with 1 Axes>"
+       "<Figure size 800x600 with 1 Axes>"
       ]
      },
      "metadata": {},
@@ -5220,10 +5220,10 @@
    ],
    "source": [
     "# 📊 Gráfico de distribuição da variável Churn\n",
-    "plt.figure(figsize=(6, 4))\n",
-    "ax = sns.countplot(data=df_t, x=\"Churn\", palette=\"pastel\")\n",
+    "plt.figure(figsize=(8, 6))\n",
+    "ax = sns.countplot(data=df_t, x=\"Churn\", palette=\"Set2\")\n",
     "plt.title(\"Distribuição de Evasão (Churn)\")\n",
-    "plt.xticks([0, 1], [\"Permaneceram\", \"Cancelaram\"])\n",
+    "plt.xticks([0, 1], [\"0\", \"1\"])\n",
     "plt.xlabel(\"Churn\")\n",
     "plt.ylabel(\"Quantidade de Clientes\")\n",
     "\n",
@@ -5239,7 +5239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 23,
    "id": "29df0251",
    "metadata": {},
    "outputs": [
@@ -5248,11 +5248,11 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_fa7cf\">\n",
+       "<table id=\"T_3d90c\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_fa7cf_level0_col0\" class=\"col_heading level0 col0\" >Percentual (%)</th>\n",
+       "      <th id=\"T_3d90c_level0_col0\" class=\"col_heading level0 col0\" >Percentual (%)</th>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th class=\"index_name level0\" >Churn</th>\n",
@@ -5261,18 +5261,18 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_fa7cf_level0_row0\" class=\"row_heading level0 row0\" >Permaneceram</th>\n",
-       "      <td id=\"T_fa7cf_row0_col0\" class=\"data row0 col0\" >73.46</td>\n",
+       "      <th id=\"T_3d90c_level0_row0\" class=\"row_heading level0 row0\" >0</th>\n",
+       "      <td id=\"T_3d90c_row0_col0\" class=\"data row0 col0\" >73.46</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_fa7cf_level0_row1\" class=\"row_heading level0 row1\" >Cancelaram</th>\n",
-       "      <td id=\"T_fa7cf_row1_col0\" class=\"data row1 col0\" >26.54</td>\n",
+       "      <th id=\"T_3d90c_level0_row1\" class=\"row_heading level0 row1\" >1</th>\n",
+       "      <td id=\"T_3d90c_row1_col0\" class=\"data row1 col0\" >26.54</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x1518688cb90>"
+       "<pandas.io.formats.style.Styler at 0x17c71b9e120>"
       ]
      },
      "metadata": {},
@@ -5281,7 +5281,7 @@
    ],
    "source": [
     "# 📌 Proporção percentual\n",
-    "churn_rate = df_t[\"Churn\"].value_counts(normalize=True).rename({0: \"Permaneceram\", 1: \"Cancelaram\"}) * 100\n",
+    "churn_rate = df_t[\"Churn\"].value_counts(normalize=True).rename({0: \"0\", 1: \"1\"}) * 100\n",
     "display(churn_rate.to_frame(\"Percentual (%)\").style.format(\"{:.2f}\"))\n"
    ]
   },
@@ -5297,7 +5297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 24,
    "id": "9ebd9015",
    "metadata": {},
    "outputs": [
@@ -5366,7 +5366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 25,
    "id": "cd3e36cc",
    "metadata": {},
    "outputs": [
@@ -5461,7 +5461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 26,
    "id": "b789f4cc",
    "metadata": {},
    "outputs": [
@@ -5469,7 +5469,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\Acer\\AppData\\Local\\Temp\\ipykernel_12044\\3984914641.py:5: SettingWithCopyWarning: \n",
+      "C:\\Users\\Acer\\AppData\\Local\\Temp\\ipykernel_28516\\3984914641.py:5: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
@@ -5611,7 +5611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 27,
    "id": "5f9f1446",
    "metadata": {},
    "outputs": [],
@@ -5637,7 +5637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 28,
    "id": "24006b17",
    "metadata": {},
    "outputs": [
@@ -5646,39 +5646,39 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_32de8\">\n",
+       "<table id=\"T_fcdd3\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_32de8_level0_col0\" class=\"col_heading level0 col0\" >customer_tenure</th>\n",
-       "      <th id=\"T_32de8_level0_col1\" class=\"col_heading level0 col1\" >account_Charges_Monthly</th>\n",
-       "      <th id=\"T_32de8_level0_col2\" class=\"col_heading level0 col2\" >account_Charges_Daily</th>\n",
-       "      <th id=\"T_32de8_level0_col3\" class=\"col_heading level0 col3\" >account_Charges_Total</th>\n",
-       "      <th id=\"T_32de8_level0_col4\" class=\"col_heading level0 col4\" >num_servicos_contratados</th>\n",
+       "      <th id=\"T_fcdd3_level0_col0\" class=\"col_heading level0 col0\" >customer_tenure</th>\n",
+       "      <th id=\"T_fcdd3_level0_col1\" class=\"col_heading level0 col1\" >account_Charges_Monthly</th>\n",
+       "      <th id=\"T_fcdd3_level0_col2\" class=\"col_heading level0 col2\" >account_Charges_Daily</th>\n",
+       "      <th id=\"T_fcdd3_level0_col3\" class=\"col_heading level0 col3\" >account_Charges_Total</th>\n",
+       "      <th id=\"T_fcdd3_level0_col4\" class=\"col_heading level0 col4\" >num_servicos_contratados</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_32de8_level0_row0\" class=\"row_heading level0 row0\" >Assimetria (skewness)</th>\n",
-       "      <td id=\"T_32de8_row0_col0\" class=\"data row0 col0\" >0.24</td>\n",
-       "      <td id=\"T_32de8_row0_col1\" class=\"data row0 col1\" >-0.22</td>\n",
-       "      <td id=\"T_32de8_row0_col2\" class=\"data row0 col2\" >-0.22</td>\n",
-       "      <td id=\"T_32de8_row0_col3\" class=\"data row0 col3\" >0.96</td>\n",
-       "      <td id=\"T_32de8_row0_col4\" class=\"data row0 col4\" >0.11</td>\n",
+       "      <th id=\"T_fcdd3_level0_row0\" class=\"row_heading level0 row0\" >Assimetria (skewness)</th>\n",
+       "      <td id=\"T_fcdd3_row0_col0\" class=\"data row0 col0\" >0.24</td>\n",
+       "      <td id=\"T_fcdd3_row0_col1\" class=\"data row0 col1\" >-0.22</td>\n",
+       "      <td id=\"T_fcdd3_row0_col2\" class=\"data row0 col2\" >-0.22</td>\n",
+       "      <td id=\"T_fcdd3_row0_col3\" class=\"data row0 col3\" >0.96</td>\n",
+       "      <td id=\"T_fcdd3_row0_col4\" class=\"data row0 col4\" >0.11</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_32de8_level0_row1\" class=\"row_heading level0 row1\" >Curtose</th>\n",
-       "      <td id=\"T_32de8_row1_col0\" class=\"data row1 col0\" >-1.39</td>\n",
-       "      <td id=\"T_32de8_row1_col1\" class=\"data row1 col1\" >-1.26</td>\n",
-       "      <td id=\"T_32de8_row1_col2\" class=\"data row1 col2\" >-1.26</td>\n",
-       "      <td id=\"T_32de8_row1_col3\" class=\"data row1 col3\" >-0.23</td>\n",
-       "      <td id=\"T_32de8_row1_col4\" class=\"data row1 col4\" >-0.99</td>\n",
+       "      <th id=\"T_fcdd3_level0_row1\" class=\"row_heading level0 row1\" >Curtose</th>\n",
+       "      <td id=\"T_fcdd3_row1_col0\" class=\"data row1 col0\" >-1.39</td>\n",
+       "      <td id=\"T_fcdd3_row1_col1\" class=\"data row1 col1\" >-1.26</td>\n",
+       "      <td id=\"T_fcdd3_row1_col2\" class=\"data row1 col2\" >-1.26</td>\n",
+       "      <td id=\"T_fcdd3_row1_col3\" class=\"data row1 col3\" >-0.23</td>\n",
+       "      <td id=\"T_fcdd3_row1_col4\" class=\"data row1 col4\" >-0.99</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x15196d6bb10>"
+       "<pandas.io.formats.style.Styler at 0x17c73327110>"
       ]
      },
      "metadata": {},
@@ -5723,7 +5723,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 29,
    "id": "e156cf45",
    "metadata": {},
    "outputs": [
@@ -5732,131 +5732,131 @@
       "text/html": [
        "<style type=\"text/css\">\n",
        "</style>\n",
-       "<table id=\"T_efe22\">\n",
+       "<table id=\"T_45f13\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_efe22_level0_col0\" class=\"col_heading level0 col0\" >Correlação com Churn</th>\n",
+       "      <th id=\"T_45f13_level0_col0\" class=\"col_heading level0 col0\" >Correlação com Churn</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row0\" class=\"row_heading level0 row0\" >account_Contract_month-to-month</th>\n",
-       "      <td id=\"T_efe22_row0_col0\" class=\"data row0 col0\" >0.41</td>\n",
+       "      <th id=\"T_45f13_level0_row0\" class=\"row_heading level0 row0\" >account_Contract_month-to-month</th>\n",
+       "      <td id=\"T_45f13_row0_col0\" class=\"data row0 col0\" >0.41</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row1\" class=\"row_heading level0 row1\" >customer_tenure</th>\n",
-       "      <td id=\"T_efe22_row1_col0\" class=\"data row1 col0\" >-0.35</td>\n",
+       "      <th id=\"T_45f13_level0_row1\" class=\"row_heading level0 row1\" >customer_tenure</th>\n",
+       "      <td id=\"T_45f13_row1_col0\" class=\"data row1 col0\" >-0.35</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row2\" class=\"row_heading level0 row2\" >internet_Service_fiber_optic</th>\n",
-       "      <td id=\"T_efe22_row2_col0\" class=\"data row2 col0\" >0.31</td>\n",
+       "      <th id=\"T_45f13_level0_row2\" class=\"row_heading level0 row2\" >internet_Service_fiber_optic</th>\n",
+       "      <td id=\"T_45f13_row2_col0\" class=\"data row2 col0\" >0.31</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row3\" class=\"row_heading level0 row3\" >account_Contract_two_year</th>\n",
-       "      <td id=\"T_efe22_row3_col0\" class=\"data row3 col0\" >-0.30</td>\n",
+       "      <th id=\"T_45f13_level0_row3\" class=\"row_heading level0 row3\" >account_Contract_two_year</th>\n",
+       "      <td id=\"T_45f13_row3_col0\" class=\"data row3 col0\" >-0.30</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row4\" class=\"row_heading level0 row4\" >account_Payment_electronic_check</th>\n",
-       "      <td id=\"T_efe22_row4_col0\" class=\"data row4 col0\" >0.30</td>\n",
+       "      <th id=\"T_45f13_level0_row4\" class=\"row_heading level0 row4\" >account_Payment_electronic_check</th>\n",
+       "      <td id=\"T_45f13_row4_col0\" class=\"data row4 col0\" >0.30</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row5\" class=\"row_heading level0 row5\" >internet_Service_no</th>\n",
-       "      <td id=\"T_efe22_row5_col0\" class=\"data row5 col0\" >-0.23</td>\n",
+       "      <th id=\"T_45f13_level0_row5\" class=\"row_heading level0 row5\" >internet_Service_no</th>\n",
+       "      <td id=\"T_45f13_row5_col0\" class=\"data row5 col0\" >-0.23</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row6\" class=\"row_heading level0 row6\" >account_Charges_Total</th>\n",
-       "      <td id=\"T_efe22_row6_col0\" class=\"data row6 col0\" >-0.20</td>\n",
+       "      <th id=\"T_45f13_level0_row6\" class=\"row_heading level0 row6\" >account_Charges_Total</th>\n",
+       "      <td id=\"T_45f13_row6_col0\" class=\"data row6 col0\" >-0.20</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row7\" class=\"row_heading level0 row7\" >account_Charges_Monthly</th>\n",
-       "      <td id=\"T_efe22_row7_col0\" class=\"data row7 col0\" >0.19</td>\n",
+       "      <th id=\"T_45f13_level0_row7\" class=\"row_heading level0 row7\" >account_Charges_Monthly</th>\n",
+       "      <td id=\"T_45f13_row7_col0\" class=\"data row7 col0\" >0.19</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row8\" class=\"row_heading level0 row8\" >account_Charges_Daily</th>\n",
-       "      <td id=\"T_efe22_row8_col0\" class=\"data row8 col0\" >0.19</td>\n",
+       "      <th id=\"T_45f13_level0_row8\" class=\"row_heading level0 row8\" >account_Charges_Daily</th>\n",
+       "      <td id=\"T_45f13_row8_col0\" class=\"data row8 col0\" >0.19</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row9\" class=\"row_heading level0 row9\" >account_is_PaperlessBilling</th>\n",
-       "      <td id=\"T_efe22_row9_col0\" class=\"data row9 col0\" >0.19</td>\n",
+       "      <th id=\"T_45f13_level0_row9\" class=\"row_heading level0 row9\" >account_is_PaperlessBilling</th>\n",
+       "      <td id=\"T_45f13_row9_col0\" class=\"data row9 col0\" >0.19</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row10\" class=\"row_heading level0 row10\" >account_Contract_one_year</th>\n",
-       "      <td id=\"T_efe22_row10_col0\" class=\"data row10 col0\" >-0.18</td>\n",
+       "      <th id=\"T_45f13_level0_row10\" class=\"row_heading level0 row10\" >account_Contract_one_year</th>\n",
+       "      <td id=\"T_45f13_row10_col0\" class=\"data row10 col0\" >-0.18</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row11\" class=\"row_heading level0 row11\" >internet_has_OnlineSecurity</th>\n",
-       "      <td id=\"T_efe22_row11_col0\" class=\"data row11 col0\" >-0.17</td>\n",
+       "      <th id=\"T_45f13_level0_row11\" class=\"row_heading level0 row11\" >internet_has_OnlineSecurity</th>\n",
+       "      <td id=\"T_45f13_row11_col0\" class=\"data row11 col0\" >-0.17</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row12\" class=\"row_heading level0 row12\" >internet_has_TechSupport</th>\n",
-       "      <td id=\"T_efe22_row12_col0\" class=\"data row12 col0\" >-0.16</td>\n",
+       "      <th id=\"T_45f13_level0_row12\" class=\"row_heading level0 row12\" >internet_has_TechSupport</th>\n",
+       "      <td id=\"T_45f13_row12_col0\" class=\"data row12 col0\" >-0.16</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row13\" class=\"row_heading level0 row13\" >customer_has_Dependents</th>\n",
-       "      <td id=\"T_efe22_row13_col0\" class=\"data row13 col0\" >-0.16</td>\n",
+       "      <th id=\"T_45f13_level0_row13\" class=\"row_heading level0 row13\" >customer_has_Dependents</th>\n",
+       "      <td id=\"T_45f13_row13_col0\" class=\"data row13 col0\" >-0.16</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row14\" class=\"row_heading level0 row14\" >customer_is_SeniorCitizen</th>\n",
-       "      <td id=\"T_efe22_row14_col0\" class=\"data row14 col0\" >0.15</td>\n",
+       "      <th id=\"T_45f13_level0_row14\" class=\"row_heading level0 row14\" >customer_is_SeniorCitizen</th>\n",
+       "      <td id=\"T_45f13_row14_col0\" class=\"data row14 col0\" >0.15</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row15\" class=\"row_heading level0 row15\" >customer_has_Partner</th>\n",
-       "      <td id=\"T_efe22_row15_col0\" class=\"data row15 col0\" >-0.15</td>\n",
+       "      <th id=\"T_45f13_level0_row15\" class=\"row_heading level0 row15\" >customer_has_Partner</th>\n",
+       "      <td id=\"T_45f13_row15_col0\" class=\"data row15 col0\" >-0.15</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row16\" class=\"row_heading level0 row16\" >account_Payment_credit_card_(automatic)</th>\n",
-       "      <td id=\"T_efe22_row16_col0\" class=\"data row16 col0\" >-0.13</td>\n",
+       "      <th id=\"T_45f13_level0_row16\" class=\"row_heading level0 row16\" >account_Payment_credit_card_(automatic)</th>\n",
+       "      <td id=\"T_45f13_row16_col0\" class=\"data row16 col0\" >-0.13</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row17\" class=\"row_heading level0 row17\" >internet_Service_dsl</th>\n",
-       "      <td id=\"T_efe22_row17_col0\" class=\"data row17 col0\" >-0.12</td>\n",
+       "      <th id=\"T_45f13_level0_row17\" class=\"row_heading level0 row17\" >internet_Service_dsl</th>\n",
+       "      <td id=\"T_45f13_row17_col0\" class=\"data row17 col0\" >-0.12</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row18\" class=\"row_heading level0 row18\" >account_Payment_bank_transfer_(automatic)</th>\n",
-       "      <td id=\"T_efe22_row18_col0\" class=\"data row18 col0\" >-0.12</td>\n",
+       "      <th id=\"T_45f13_level0_row18\" class=\"row_heading level0 row18\" >account_Payment_bank_transfer_(automatic)</th>\n",
+       "      <td id=\"T_45f13_row18_col0\" class=\"data row18 col0\" >-0.12</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row19\" class=\"row_heading level0 row19\" >account_Payment_mailed_check</th>\n",
-       "      <td id=\"T_efe22_row19_col0\" class=\"data row19 col0\" >-0.09</td>\n",
+       "      <th id=\"T_45f13_level0_row19\" class=\"row_heading level0 row19\" >account_Payment_mailed_check</th>\n",
+       "      <td id=\"T_45f13_row19_col0\" class=\"data row19 col0\" >-0.09</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row20\" class=\"row_heading level0 row20\" >internet_has_OnlineBackup</th>\n",
-       "      <td id=\"T_efe22_row20_col0\" class=\"data row20 col0\" >-0.08</td>\n",
+       "      <th id=\"T_45f13_level0_row20\" class=\"row_heading level0 row20\" >internet_has_OnlineBackup</th>\n",
+       "      <td id=\"T_45f13_row20_col0\" class=\"data row20 col0\" >-0.08</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row21\" class=\"row_heading level0 row21\" >internet_has_DeviceProtection</th>\n",
-       "      <td id=\"T_efe22_row21_col0\" class=\"data row21 col0\" >-0.07</td>\n",
+       "      <th id=\"T_45f13_level0_row21\" class=\"row_heading level0 row21\" >internet_has_DeviceProtection</th>\n",
+       "      <td id=\"T_45f13_row21_col0\" class=\"data row21 col0\" >-0.07</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row22\" class=\"row_heading level0 row22\" >internet_has_StreamingTV</th>\n",
-       "      <td id=\"T_efe22_row22_col0\" class=\"data row22 col0\" >0.06</td>\n",
+       "      <th id=\"T_45f13_level0_row22\" class=\"row_heading level0 row22\" >internet_has_StreamingTV</th>\n",
+       "      <td id=\"T_45f13_row22_col0\" class=\"data row22 col0\" >0.06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row23\" class=\"row_heading level0 row23\" >internet_has_StreamingMovies</th>\n",
-       "      <td id=\"T_efe22_row23_col0\" class=\"data row23 col0\" >0.06</td>\n",
+       "      <th id=\"T_45f13_level0_row23\" class=\"row_heading level0 row23\" >internet_has_StreamingMovies</th>\n",
+       "      <td id=\"T_45f13_row23_col0\" class=\"data row23 col0\" >0.06</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row24\" class=\"row_heading level0 row24\" >phone_has_MultipleLines</th>\n",
-       "      <td id=\"T_efe22_row24_col0\" class=\"data row24 col0\" >0.04</td>\n",
+       "      <th id=\"T_45f13_level0_row24\" class=\"row_heading level0 row24\" >phone_has_MultipleLines</th>\n",
+       "      <td id=\"T_45f13_row24_col0\" class=\"data row24 col0\" >0.04</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row25\" class=\"row_heading level0 row25\" >num_servicos_contratados</th>\n",
-       "      <td id=\"T_efe22_row25_col0\" class=\"data row25 col0\" >0.02</td>\n",
+       "      <th id=\"T_45f13_level0_row25\" class=\"row_heading level0 row25\" >num_servicos_contratados</th>\n",
+       "      <td id=\"T_45f13_row25_col0\" class=\"data row25 col0\" >0.02</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row26\" class=\"row_heading level0 row26\" >phone_has_PhoneService</th>\n",
-       "      <td id=\"T_efe22_row26_col0\" class=\"data row26 col0\" >0.01</td>\n",
+       "      <th id=\"T_45f13_level0_row26\" class=\"row_heading level0 row26\" >phone_has_PhoneService</th>\n",
+       "      <td id=\"T_45f13_row26_col0\" class=\"data row26 col0\" >0.01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_efe22_level0_row27\" class=\"row_heading level0 row27\" >customer_gender_is_Male</th>\n",
-       "      <td id=\"T_efe22_row27_col0\" class=\"data row27 col0\" >-0.01</td>\n",
+       "      <th id=\"T_45f13_level0_row27\" class=\"row_heading level0 row27\" >customer_gender_is_Male</th>\n",
+       "      <td id=\"T_45f13_row27_col0\" class=\"data row27 col0\" >-0.01</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x15196d6bb10>"
+       "<pandas.io.formats.style.Styler at 0x17c73327110>"
       ]
      },
      "metadata": {},
@@ -5888,7 +5888,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 30,
    "id": "98b9d824",
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
Este Pull Request aplica correções visuais nos gráficos relacionados à distribuição de churn, garantindo:

✔️ Legendas claras com a distinção entre "Clientes que permaneceram" e "Clientes que saíram"
✔️ Cores padronizadas e consistentes (azul/vermelho)
✔️ Rótulos explícitos na legenda dos histogramas e boxplots

Essas melhorias visam tornar os gráficos mais informativos e legíveis para análise e apresentação dos resultados.

Esta PR complementa a PR anterior que implementou o pipeline completo de ETL e análise do desafio TelecomX.
